### PR TITLE
Reduce visibility of RPC status messages, format regtest output

### DIFF
--- a/bitcoin-rpc/build.gradle
+++ b/bitcoin-rpc/build.gradle
@@ -99,8 +99,13 @@ task regTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
     outputs.upToDateWhen { false }
     testLogging.showStandardStreams = true
+    beforeSuite { descriptor ->
+        if (descriptor.getClassName() != null) {
+            logger.lifecycle('\033[1m' + descriptor.getName() + "\033[0m") // bold
+        }
+    }
     beforeTest { descriptor ->
-        logger.lifecycle("\n** Running test: " + descriptor)
+        logger.lifecycle('    ' + descriptor.getName())
     }
 
     systemProperty 'regtest', true

--- a/bitcoin-rpc/src/integ/groovy/com/msgilligan/bitcoin/BaseRegTestSpec.groovy
+++ b/bitcoin-rpc/src/integ/groovy/com/msgilligan/bitcoin/BaseRegTestSpec.groovy
@@ -19,7 +19,7 @@ class BaseRegTestSpec extends Specification implements BTCTestSupport, Loggable 
     }
 
     void setupSpec() {
-        log.info "Waiting for server..."
+        log.debug "Waiting for server..."
         Boolean available = client.waitForServer(60)   // Wait up to 1 minute
         if (!available) {
             log.error "Timeout error."

--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -46,7 +46,7 @@ public class BitcoinClient extends RPCClient {
     public Boolean waitForServer(Integer timeout) throws JsonRPCException {
         Integer seconds = 0;
 
-        System.err.println("Waiting for server RPC ready:");
+        log.debug("Waiting for server RPC ready:");
 
         Integer block;
 
@@ -54,7 +54,7 @@ public class BitcoinClient extends RPCClient {
             try {
                 block = this.getBlockCount();
                 if (block != null ) {
-                    System.err.println("\nRPC Ready.");
+                    log.debug("\nRPC Ready.");
                     return true;
                 }
             } catch (SocketException se ) {

--- a/omnij-rpc/build.gradle
+++ b/omnij-rpc/build.gradle
@@ -104,8 +104,13 @@ task regTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
     outputs.upToDateWhen { false }
     testLogging.showStandardStreams = true
+    beforeSuite { descriptor ->
+        if (descriptor.getClassName() != null) {
+            logger.lifecycle('\033[1m' + descriptor.getName() + "\033[0m") // bold
+        }
+    }
     beforeTest { descriptor ->
-        logger.lifecycle("\n** Running test: " + descriptor)
+        logger.lifecycle('    ' + descriptor.getName())
     }
 
     systemProperty 'regtest', true

--- a/omnij-rpc/src/integ/groovy/foundation/omni/BaseMainNetSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/BaseMainNetSpec.groovy
@@ -29,7 +29,7 @@ abstract class BaseMainNetSpec extends Specification implements OmniClientDelega
      * Wait for RPC server to be responding and to be in sync with the Bitcoin Blockchain
      */
     void setupSpec() {
-        log.info "Waiting for server..."
+        log.debug "Waiting for server..."
         Boolean available = client.waitForServer(rpcWaitTimeoutSeconds)
         if (!available) {
             log.error "Timeout error."

--- a/omnij-rpc/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
@@ -23,7 +23,7 @@ class BaseRegTestSpec extends Specification implements OmniClientDelegate, OmniT
     }
 
     void setupSpec() {
-        log.info "Waiting for server..."
+        log.debug "Waiting for server..."
         Boolean available = client.waitForServer(60)   // Wait up to 1 minute
         if (!available) {
             log.error "Timeout error."


### PR DESCRIPTION
Example output of omnij-rpc:regTest:

<pre>
<b>foundation.omni.test.rpc.basic.SendRawTransactionSpec</b>
    Create raw transaction with reference address
    Create raw transaction without reference address
<b>foundation.omni.test.rpc.basic.OmniSpec</b>
    Implement getbalance_MP
    Return Master Core version field using getinfo_MP
<b>foundation.omni.test.rpc.dex.DexSpec</b>
    A new sell offer can be created with Action = 1 (New)
    An accepted currency identifier for sell offers is CurrencyID:1
    An accepted currency identifier for sell offers is CurrencyID:2
    Offering more tokens than available puts up an offer with the available amount
    ...
</pre>

See #68 for the discussion.