### PR TITLE
Add RPC commands and tests for block reorganizations

### DIFF
--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -218,6 +218,14 @@ public class BitcoinClient extends RPCClient {
         send("reconsiderblock", params);
     }
 
+    /**
+     * @return Information about all known tips in the block tree.
+     */
+    public List<Map<String, Object>> getChainTips()  throws JsonRPCException, IOException {
+        List<Map<String, Object>> tips = send("getchaintips", null);
+        return tips;
+    }
+
     public Address getNewAddress() throws JsonRPCException, IOException {
         return getNewAddress(null);
     }

--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -196,6 +196,16 @@ public class BitcoinClient extends RPCClient {
         return setGenerate(true, blocks);
     }
 
+    /**
+     * Permanently marks a block as invalid, as if it violated a consensus rule.
+     *
+     * @param hash The block hash
+     */
+    public void invalidateBlock(Sha256Hash hash)  throws JsonRPCException, IOException {
+        List<Object> params = createParamList(hash.toString());
+        send("invalidateblock", params);
+    }
+
     public Address getNewAddress() throws JsonRPCException, IOException {
         return getNewAddress(null);
     }

--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -206,6 +206,18 @@ public class BitcoinClient extends RPCClient {
         send("invalidateblock", params);
     }
 
+    /**
+     * Removes invalidity status of a block and its descendants, reconsider them for activation.
+     *
+     * This can be used to undo the effects of "invalidateblock".
+     *
+     * @param hash The hash of the block to reconsider
+     */
+    public void reconsiderBlock(Sha256Hash hash)  throws JsonRPCException, IOException {
+        List<Object> params = createParamList(hash.toString());
+        send("reconsiderblock", params);
+    }
+
     public Address getNewAddress() throws JsonRPCException, IOException {
         return getNewAddress(null);
     }

--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -226,6 +226,21 @@ public class BitcoinClient extends RPCClient {
         return tips;
     }
 
+    /**
+     * Clears the memory pool and returns a list of the removed transactions.
+     *
+     * @return A list of transaction hashes of the removed transactions
+     */
+    public List<Sha256Hash> clearMemPool() throws JsonRPCException, IOException {
+        List<String> hashesStr = send("clearmempool", null);
+        List<Sha256Hash> hashes = new ArrayList<Sha256Hash>();
+        for (String s : hashesStr) {
+            Sha256Hash hash = new Sha256Hash(s);
+            hashes.add(hash);
+        }
+        return hashes;
+    }
+
     public Address getNewAddress() throws JsonRPCException, IOException {
         return getNewAddress(null);
     }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/BaseReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/BaseReorgSpec.groovy
@@ -1,0 +1,56 @@
+package foundation.omni.test.rpc.reorgs
+
+import com.msgilligan.bitcoin.rpc.JsonRPCException
+import foundation.omni.BaseRegTestSpec
+import org.bitcoinj.core.Sha256Hash
+import org.junit.internal.AssumptionViolatedException
+
+class BaseReorgSpec extends BaseRegTestSpec {
+
+    static protected BigDecimal startBTC = 0.1
+    static protected BigDecimal startMSC = 0.2
+
+    def setupSpec() {
+        try {
+            clearMemPool()
+        } catch(JsonRPCException ignored) {
+            throw new AssumptionViolatedException('The client has no "clearmempool" command')
+        }
+    }
+
+    Sha256Hash generateAndGetBlockHash() throws AssumptionViolatedException
+    {
+        List<String> result = generateBlock() as List<String>
+        if (result == null) {
+            throw new AssumptionViolatedException('The client is not based on Bitcoin Core 0.10')
+        }
+        assert result.size() > 0
+        return new Sha256Hash(result[0])
+    }
+
+    Boolean checkTransactionValidity(Sha256Hash txid, Integer confirmationsLimit = 1)
+    {
+        try {
+            def transaction = getRawTransaction(txid, true) as Map<String, Object>
+            if (transaction.confirmations < confirmationsLimit) {
+                return false
+            }
+        } catch(Exception ignored) {
+            return false
+        }
+        try {
+            def transaction = getTransactionMP(txid)
+            if (transaction.valid != true) {
+                return false
+            }
+            if (transaction.confirmations < confirmationsLimit) {
+                return false
+            }
+        } catch(Exception ignored) {
+            return false
+        }
+
+        return true
+    }
+
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
@@ -1,0 +1,99 @@
+package foundation.omni.test.rpc.reorgs
+
+import com.msgilligan.bitcoin.rpc.JsonRPCStatusException
+import foundation.omni.CurrencyID
+import foundation.omni.Ecosystem
+import foundation.omni.PropertyType
+import foundation.omni.rpc.SmartPropertyListInfo
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class PropertyCreationReorgSpec extends BaseReorgSpec {
+
+    @Shared
+    List<SmartPropertyListInfo> propertyListAtStart
+
+    @Shared
+    CurrencyID nextMainPropertyID
+
+    @Shared
+    CurrencyID nextTestPropertyID
+
+    def setupSpec() {
+        propertyListAtStart = listproperties_MP()
+        def mainProperties = propertyListAtStart.findAll { it.id.ecosystem == Ecosystem.MSC }
+        def testProperties = propertyListAtStart.findAll { it.id.ecosystem == Ecosystem.TMSC }
+        def lastMainPropertyID = mainProperties.last().id
+        def lastTestPropertyID = testProperties.last().id
+
+        if (lastMainPropertyID == CurrencyID.MSC) {
+            nextMainPropertyID = new CurrencyID(CurrencyID.TMSC_VALUE + 1)
+        } else {
+            nextMainPropertyID = new CurrencyID(lastMainPropertyID.longValue() + 1)
+        }
+
+        if (lastTestPropertyID == CurrencyID.TMSC) {
+            nextTestPropertyID = new CurrencyID(2147483651L)
+        } else {
+            nextTestPropertyID = new CurrencyID(lastTestPropertyID.longValue() + 1)
+        }
+    }
+
+    @Unroll
+    def "In #ecosystem, after invalidating the creation of #propertyType, the transaction and the property are invalid"()
+    {
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+
+        when: "broadcasting and confirming a property creation transaction"
+        def txid = createProperty(actorAddress, ecosystem, propertyType, numberOfTokens.longValue())
+        def blockHashOfCreation = generateAndGetBlockHash()
+
+        then: "the transaction is valid"
+        checkTransactionValidity(txid)
+
+        and: "a new property was created"
+        listproperties_MP().size() == propertyListAtStart.size() + 1
+
+        and: "the created property is in the correct ecosystem"
+        def txCreation = getTransactionMP(txid)
+        def currencyID = new CurrencyID(txCreation.propertyid as long)
+        currencyID.ecosystem == ecosystem
+
+        and: "it has the expected next currency identifier"
+        currencyID == expectedCurrencyID
+
+        and: "the creator was credited with the correct amount of created tokens"
+        getbalance_MP(actorAddress, currencyID).balance == expectedBalance
+
+        when: "invalidating the block and property creation transaction"
+        invalidateBlock(blockHashOfCreation)
+        clearMemPool()
+        generateBlock()
+
+        then: "the transaction is no longer valid"
+        !checkTransactionValidity(txid)
+
+        and: "the created property is no longer listed"
+        listproperties_MP().size() == propertyListAtStart.size()
+
+        when:
+        getproperty_MP(currencyID)
+
+        then: "no information about the property is available"
+        thrown(JsonRPCStatusException)
+
+        when:
+        getbalance_MP(actorAddress, currencyID)
+
+        then: "no balance information for the property"
+        thrown(JsonRPCStatusException)
+
+        where:
+        ecosystem      | propertyType             | numberOfTokens        | expectedBalance               | expectedCurrencyID
+        Ecosystem.MSC  | PropertyType.INDIVISIBLE | new Long("150")       | new BigDecimal("150")         | nextMainPropertyID
+        Ecosystem.MSC  | PropertyType.DIVISIBLE   | new Long("100000000") | new BigDecimal("1.00000000")  | nextMainPropertyID
+        Ecosystem.TMSC | PropertyType.INDIVISIBLE | new Long("350")       | new BigDecimal("350")         | nextTestPropertyID
+        Ecosystem.TMSC | PropertyType.DIVISIBLE   | new Long("250000000") | new BigDecimal("2.50000000")  | nextTestPropertyID
+    }
+
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
@@ -1,0 +1,108 @@
+package foundation.omni.test.rpc.reorgs
+
+import foundation.omni.CurrencyID
+import foundation.omni.Ecosystem
+import foundation.omni.PropertyType
+
+class SendToOwnersReorgSpec extends BaseReorgSpec {
+
+    def "After invalidating a send to owners transaction, the transaction is invalid"()
+    {
+        given:
+        def sendAmount = new BigDecimal("0.1")
+        def senderAddress = createFundedAddress(startBTC, startMSC)
+        def dummyOwnerAddress = createFundedAddress(startBTC, startMSC)
+
+        when: "broadcasting and confirming a send to owners transaction"
+        def txid = sendToOwnersMP(senderAddress, CurrencyID.TMSC, sendAmount)
+        def blockHashOfSend = generateAndGetBlockHash()
+
+        then: "the transaction is valid"
+        checkTransactionValidity(txid)
+
+        when: "invalidating the block and send to owners transaction"
+        invalidateBlock(blockHashOfSend)
+        clearMemPool()
+        generateBlock()
+
+        then: "the send transaction is no longer valid"
+        !checkTransactionValidity(txid)
+    }
+
+    def "After invalidating a send to owners transaction, the original balances are restored"()
+    {
+        given:
+        def senderAddress = createFundedAddress(startBTC, startMSC)
+        def dummyOwnerA = newAddress
+        def dummyOwnerB = newAddress
+        def dummyOwnerC = newAddress
+
+        def ecosystem = Ecosystem.MSC
+        def propertyType = PropertyType.INDIVISIBLE
+        def amountToCreate = new BigDecimal("153")
+
+        def txidCreation = createProperty(senderAddress, ecosystem, propertyType, amountToCreate.longValue())
+        generateBlock()
+        def txCreation = getTransactionMP(txidCreation)
+        def currencyID = new CurrencyID(txCreation.propertyid as long)
+
+        when: "funding the owners with a new property"
+        send_MP(senderAddress, dummyOwnerA, currencyID, new BigDecimal("1"))
+        send_MP(senderAddress, dummyOwnerB, currencyID, new BigDecimal("1"))
+        send_MP(senderAddress, dummyOwnerC, currencyID, new BigDecimal("1"))
+        def blockHashOfOwnerFunding = generateAndGetBlockHash()
+
+        then: "the owners have some balance"
+        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("1")
+        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("1")
+        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("1")
+
+        and: "the sender has less"
+        getbalance_MP(senderAddress, currencyID).balance == new BigDecimal("150")
+
+        when: "sending to the owners"
+        def txidSTO = sendToOwnersMP(senderAddress, currencyID, new BigDecimal("150"))
+        def blockHashOfSend = generateAndGetBlockHash()
+
+        then: "the send to owners transaction is valid"
+        checkTransactionValidity(txidSTO)
+
+        and: "the owners received the tokens"
+        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("51")
+        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("51")
+        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("51")
+
+        and: "the sender has no more tokens"
+        getbalance_MP(senderAddress, currencyID).balance == new BigDecimal("0")
+
+        when: "invalidating the block and send to owners transaction"
+        invalidateBlock(blockHashOfSend)
+        clearMemPool()
+        generateBlock()
+
+        then: "the send to owners transaction is no longer valid"
+        !checkTransactionValidity(txidSTO)
+
+        and: "the owners no longer have the tokens they received"
+        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("1")
+        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("1")
+        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("1")
+
+        and: "the sender has the balance from before the send to owners transaction"
+        getbalance_MP(senderAddress, currencyID).balance == new BigDecimal("150")
+
+        when: "rolling back until before the funding of the owners"
+        invalidateBlock(blockHashOfOwnerFunding)
+        clearMemPool()
+        generateBlock()
+
+        then: "the owners have no tokens"
+        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("0")
+        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("0")
+        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("0")
+
+        and: "the sender has the initial amount that was created"
+        getbalance_MP(senderAddress, currencyID).balance == amountToCreate
+    }
+
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SimpleSendReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SimpleSendReorgSpec.groovy
@@ -1,0 +1,77 @@
+package foundation.omni.test.rpc.reorgs
+
+import foundation.omni.CurrencyID
+
+class SimpleSendReorgSpec extends BaseReorgSpec {
+
+    final static BigDecimal sendAmount = 0.1
+
+    def "After invalidating a simple send, the send transaction is invalid"()
+    {
+        given:
+        def receiverAddress = newAddress
+        def senderAddress = createFundedAddress(startBTC, startMSC)
+        def blockCountBeforeSend = getBlockCount()
+
+        when: "broadcasting and confirming a simple send"
+        def txid = send_MP(senderAddress, receiverAddress, CurrencyID.MSC, sendAmount)
+        def blockHashOfSend = generateAndGetBlockHash()
+
+        then: "the transaction is valid"
+        checkTransactionValidity(txid)
+
+        when: "invalidating the block with the send transaction"
+        invalidateBlock(blockHashOfSend)
+
+        then: "the send transaction is no longer confirmed"
+        getBlockCount() == blockCountBeforeSend
+        getTransaction(txid).confirmations < 1
+
+        when: "a new block is mined"
+        clearMemPool()
+        generateBlock()
+
+        then: "the send transaction is no longer valid"
+        !checkTransactionValidity(txid)
+    }
+
+    def "After invalidating a simple send, the original balances are restored"()
+    {
+        def blockHashBeforeFunding = generateAndGetBlockHash()
+
+        def receiverAddress = newAddress
+        def senderAddress = createFundedAddress(startBTC, startMSC)
+
+        def balanceBeforeSendActor = getbalance_MP(senderAddress, CurrencyID.MSC)
+        def balanceBeforeSendReceiver = getbalance_MP(receiverAddress, CurrencyID.MSC)
+
+        when: "broadcasting and confirming a simple send"
+        def txid = send_MP(senderAddress, receiverAddress, CurrencyID.MSC, sendAmount)
+        def blockHashOfSend = generateAndGetBlockHash()
+
+        then: "the transaction is valid and the tokens were transferred"
+        checkTransactionValidity(txid)
+        getbalance_MP(senderAddress, CurrencyID.MSC).balance == balanceBeforeSendActor.balance - sendAmount
+        getbalance_MP(receiverAddress, CurrencyID.MSC).balance == balanceBeforeSendReceiver.balance + sendAmount
+
+        when: "invalidating the block with the send transaction and after a new block is mined"
+        invalidateBlock(blockHashOfSend)
+        clearMemPool()
+        generateBlock()
+
+        then: "the send transaction is no longer valid and the balances before the send are restored"
+        !checkTransactionValidity(txid)
+        getbalance_MP(senderAddress, CurrencyID.MSC) == balanceBeforeSendActor
+        getbalance_MP(receiverAddress, CurrencyID.MSC) == balanceBeforeSendReceiver
+
+        when: "rolling back all blocks until before the initial funding"
+        invalidateBlock(blockHashBeforeFunding)
+        clearMemPool()
+        generateBlock()
+
+        then: "the actors have zero balances"
+        getbalance_MP(senderAddress, CurrencyID.MSC).balance == 0.0
+        getbalance_MP(receiverAddress, CurrencyID.MSC).balance == 0.0
+    }
+
+}


### PR DESCRIPTION
This PR adds the required RPC calls (and some related) to test block reorganzations.

The tested transaction types and aspects of Omni Core are:

- simple send
- send to owners
- property creation

There are two significant downsides: the `"invalidateblock"` command was introduced with Bitcoin Core 0.10, and is therefore not available on the CI server, but worse: I had no handy way to clear the memory pool, and added an [extra extension](https://github.com/dexX7/bitcoin/compare/e687023daf4c4720d6804d7dcc51b8df2bc55684...dexX7:oc-0.10-rpc-clearmempool) for this.

All reorganization tests are skipped, if `"clearmempool"` is not available, or if `"setgenerate"` doesn't return a list of block hashes, indicating a client version, which is not based on 0.10.

I'm not sure, if this PR should be merged, given the context. Ideally, there would be a workaround to clear the memory pool, the client version properly detected, and tests ignored otherwise, instead of being skipped.