### PR TITLE
Additional tests for transaction type 53, 55 and 56

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CloseCrowdsaleSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CloseCrowdsaleSpec.groovy
@@ -1,0 +1,118 @@
+package foundation.omni.test.rpc.crowdsale
+
+import foundation.omni.BaseRegTestSpec
+import foundation.omni.CurrencyID
+import foundation.omni.Ecosystem
+import foundation.omni.PropertyType
+import org.bitcoinj.core.Address
+import spock.lang.Shared
+
+class CloseCrowdsaleSpec extends BaseRegTestSpec {
+
+    final static BigDecimal startBTC = 0.01
+    final static BigDecimal startMSC = 1.00
+
+    @Shared Address actorAddress
+    @Shared Address otherAddress
+    @Shared CurrencyID currencyID
+    @Shared CurrencyID nonCrowdsaleID
+
+    def setupSpec() {
+        actorAddress = createFundedAddress(startBTC, startMSC)
+        otherAddress = createFundedAddress(startBTC, startMSC)
+
+        def txid = createCrowdsale(actorAddress, Ecosystem.TMSC, PropertyType.DIVISIBLE, CurrencyID.TMSC, 500000000L,
+                                   2147483648L, 0 as Byte, 0 as Byte)
+        generateBlock()
+        def creationTx = getTransactionMP(txid)
+        assert (creationTx.valid)
+        currencyID = new CurrencyID(creationTx.propertyid as Long)
+        nonCrowdsaleID = fundNewProperty(actorAddress, 500.0, PropertyType.DIVISIBLE, Ecosystem.TMSC)
+    }
+
+    def "Closing a non-existing crowdsale is invalid"() {
+        when:
+        def txid = closeCrowdsale(actorAddress, new CurrencyID(CurrencyID.MAX_REAL_ECOSYSTEM_VALUE))
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid == false
+    }
+
+    def "Closing a non-crowdsale is invalid"() {
+        when:
+        def txid = closeCrowdsale(actorAddress, nonCrowdsaleID)
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid == false
+    }
+
+    def "A crowdsale can not be closed by a non-issuer"() {
+        when:
+        def txid = closeCrowdsale(otherAddress, currencyID)
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid == false
+
+        and:
+        getcrowdsale_MP(currencyID).active
+    }
+
+    def "Before closing a crowdsale, tokens can be purchased"() {
+        when:
+        def txid = send_MP(otherAddress, actorAddress, CurrencyID.TMSC, 0.5)
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid
+
+        and:
+        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == 1.5
+        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == 0.5
+
+        and: "tokens were credited to the participant"
+        getbalance_MP(actorAddress, currencyID).balance == 0.0
+        getbalance_MP(otherAddress, currencyID).balance == 2.5
+    }
+
+    def "A crowdsale can be closed with transaction type 53"() {
+        when:
+        def txid = closeCrowdsale(actorAddress, currencyID)
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid
+
+        and:
+        getcrowdsale_MP(currencyID).active == false
+    }
+
+    def "A crowdsale can only be closed once"() {
+        when:
+        def txid = closeCrowdsale(actorAddress, currencyID)
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid == false
+    }
+
+    def "Sending tokens, after a crowdsale was closed, does not grant tokens"() {
+        when:
+        def txid = send_MP(otherAddress, actorAddress, CurrencyID.TMSC, 0.5)
+        generateBlock()
+
+        then:
+        getTransactionMP(txid).valid
+
+        and:
+        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == 2.0
+        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == 0.0
+
+        and: "no tokens were credited to the participant"
+        getbalance_MP(actorAddress, currencyID) == old(getbalance_MP(actorAddress, currencyID))
+        getbalance_MP(otherAddress, currencyID) == old(getbalance_MP(otherAddress, currencyID))
+    }
+
+}

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
@@ -112,6 +112,29 @@ public class OmniExtendedClient extends OmniClient {
     }
 
     /**
+     * Creates a crowdsale.
+     *
+     * @param address          The issuance address
+     * @param ecosystem        The ecosystem to create the crowdsale in
+     * @param propertyType     The property type
+     * @param propertyDesired  The desired property
+     * @param tokensPerUnit    The number of tokens per unit invested
+     * @param deadline         The deadline as UNIX timestamp
+     * @param earlyBirdBonus   The bonus percentage per week
+     * @param issuerBonus      The bonus for the issuer
+     * @return The transaction hash
+     */
+    public Sha256Hash createCrowdsale(Address address, Ecosystem ecosystem, PropertyType propertyType,
+                                      CurrencyID propertyDesired, Long tokensPerUnit, Long deadline,
+                                      Byte earlyBirdBonus, Byte issuerBonus)
+            throws JsonRPCException, IOException {
+        String rawTxHex = builder.createCrowdsaleHex(ecosystem, propertyType, 0L, "", "", "CS", "", "", propertyDesired,
+                                                     tokensPerUnit, deadline, earlyBirdBonus, issuerBonus);
+        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        return txid;
+    }
+
+    /**
      * Creates a smart property with fixed supply.
      *
      * @param address    The issuance address
@@ -138,6 +161,19 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash createProperty(Address address, Ecosystem ecosystem, PropertyType type, Long amount, String label)
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createPropertyHex(ecosystem, type, 0L, "", "", label, "", "", amount);
+        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        return txid;
+    }
+
+    /**
+     * Closes a crowdsale.
+     *
+     * @param address     The issuance address
+     * @param currencyID  The identifier of the crowdsale
+     * @return The transaction hash
+     */
+    public Sha256Hash closeCrowdsale(Address address, CurrencyID currencyID) throws JsonRPCException, IOException {
+        String rawTxHex = builder.createCloseCrowdsaleHex(currencyID);
         Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
         return txid;
     }
@@ -191,6 +227,21 @@ public class OmniExtendedClient extends OmniClient {
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createRevokeTokensHex(currencyID, amount, "");
         Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        return txid;
+    }
+
+    /**
+     * Changes the issuer on record of a managed property.
+     *
+     * @param fromAddress  The issuance address
+     * @param currencyID   The identifier of the property
+     * @param toAddress    The new issuer on record
+     * @return The transaction hash
+     */
+    public Sha256Hash changeIssuer(Address fromAddress, CurrencyID currencyID, Address toAddress)
+            throws JsonRPCException, IOException {
+        String rawTxHex = builder.createChangePropertyManagerHex(currencyID);
+        Sha256Hash txid = sendrawtx_MP(fromAddress, rawTxHex, toAddress);
         return txid;
     }
 


### PR DESCRIPTION
Transaction type 53 (close crowdsale):

 - "Closing a non-existing crowdsale is invalid"
 - "Closing a non-crowdsale is invalid"
 - "A crowdsale can not be closed by a non-issuer"
 - "Before closing a crowdsale, tokens can be purchased"
 - "A crowdsale can be closed with transaction type 53"
 - "A crowdsale can only be closed once"
 - "Sending tokens, after a crowdsale was closed, does not grant tokens",

Transaction type 55 (grant tokens for managed property):

 - "It's impossible to grant tokens for an non-existing property"
 - "Granting tokens for a property with fixed supply is invalid"

Transaction type 56 (revoke  tokens for managed property):

 - "It's impossible to revoke tokens for an non-existing property"
 - "Revoking tokens for a property with fixed supply is invalid""