### PR TITLE
Refine waitForServer() logging

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/BaseMainNetSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/BaseMainNetSpec.groovy
@@ -58,6 +58,6 @@ abstract class BaseMainNetSpec extends Specification implements OmniClientDelega
             mscVersion = info.mastercoreversion
         }
         log.info "Bitcoin version: ${info.version}"
-        log.info "Mastercore version: ${mscVersion}"
+        log.info "Omni Core version: ${mscVersion}"
     }
 }


### PR DESCRIPTION
As described in https://github.com/OmniLayer/OmniJ/issues/74#issuecomment-116428633:

- status messages are logged only once, if new or updated
- status messages are logged as `INFO`
- begin and end of waiting is logged as `DEBUG`