### PR TITLE
Don't skip blocks during initial parsing

### DIFF
--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -5,3 +5,4 @@ rpcallowip=127.0.0.1
 txindex=1
 debug=1
 logtimestamps=1
+omniseedblockfilter=0


### PR DESCRIPTION
The speed of the initial parsing can be increased by skipping predefined blocks.

Parsing with enabled skipping is less thorough though.

Since OmniJ/CI server is all about testing, we probably don't want this.

@msgilligan: if this config file isn't consumed by the CI server, it would be great, if you could update the scripts and include `omniseedblockfilter=0` in the `bitcoin.conf`, or use `-omniseedblockfilter=0` as command-line option.

The related PR is https://github.com/OmniLayer/omnicore/pull/135.