### PR TITLE
Add tests for "Send All" transaction type

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
@@ -1,0 +1,122 @@
+package foundation.omni.test.rpc.sendall
+
+import foundation.omni.BaseRegTestSpec
+import foundation.omni.CurrencyID
+import foundation.omni.Ecosystem
+import foundation.omni.PropertyType
+import org.junit.internal.AssumptionViolatedException
+
+class SendAllSpec extends BaseRegTestSpec {
+
+    final static BigDecimal startBTC = 0.1
+    final static BigDecimal startMSC = 0.1
+    final static BigDecimal zeroAmount = 0.0
+
+    def "All available tokens can be transferred with transaction type 4"() {
+        when:
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def otherAddress = newAddress
+
+        then:
+        getbalance_MP(actorAddress, CurrencyID.MSC).balance == startMSC
+        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == startMSC
+        getbalance_MP(otherAddress, CurrencyID.MSC).balance == zeroAmount
+        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == zeroAmount
+
+        when:
+        def sendTxid = sendAll(actorAddress, otherAddress)
+        generateBlock()
+        def sendTx = getTransactionMP(sendTxid)
+
+        then: "the transaction is valid"
+        sendTx.valid
+
+        and: "it has the specified values"
+        sendTx.txid == sendTxid.toString()
+        sendTx.sendingaddress == actorAddress.toString()
+        sendTx.referenceaddress == otherAddress.toString()
+        sendTx.type_int == 4
+        sendTx.containsKey('subsends')
+
+        and:
+        List<Map<String, Object>> subSends = sendTx['subsends']
+        subSends.size() == 2
+        for (def send : subSends) {
+            assert send.divisible
+            assert send.amount as BigDecimal == startMSC
+        }
+
+        and:
+        getbalance_MP(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == zeroAmount
+        getbalance_MP(otherAddress, CurrencyID.MSC).balance == startMSC
+        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
+    }
+
+    def "\"Send All\" transactions are only valid, if at least one token was transferred"() {
+        when:
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def otherAddress = newAddress
+        send_MP(actorAddress, otherAddress, CurrencyID.MSC, startMSC)
+        send_MP(actorAddress, otherAddress, CurrencyID.TMSC, startMSC)
+        generateBlock()
+
+        then:
+        getbalance_MP(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == zeroAmount
+        getbalance_MP(otherAddress, CurrencyID.MSC).balance == startMSC
+        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
+
+        when:
+        def sendTxid = sendAll(actorAddress, otherAddress)
+        generateBlock()
+
+        then:
+        getTransactionMP(sendTxid).valid == false
+
+        and:
+        getbalance_MP(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == zeroAmount
+        getbalance_MP(otherAddress, CurrencyID.MSC).balance == startMSC
+        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
+    }
+
+    def "Only available, unreserved balances are transferred with \"Send All\""() {
+        when:
+        def actorAddress = createFundedAddress(startBTC, zeroAmount)
+        def otherAddress = createFundedAddress(startBTC, zeroAmount)
+        def nonManagedID = fundNewProperty(actorAddress, 10.0, PropertyType.DIVISIBLE, Ecosystem.MSC)
+
+        then:
+        getbalance_MP(actorAddress, nonManagedID).balance == 10.0
+        getbalance_MP(otherAddress, nonManagedID).balance == zeroAmount
+
+        when:
+        def tradeTxid = trade_MP(actorAddress, nonManagedID, 4.0, CurrencyID.MSC, 4.0, 1 as Byte)
+        generateBlock()
+        def tradeTx = getTransactionMP(tradeTxid)
+
+        then:
+        tradeTx.valid
+        getbalance_MP(actorAddress, nonManagedID).balance == 6.0
+        getbalance_MP(actorAddress, nonManagedID).reserved == 4.0
+
+        when:
+        def sendTxid = sendAll(actorAddress, otherAddress)
+        generateBlock()
+        def sendTx = getTransactionMP(sendTxid)
+
+        then:
+        sendTx.valid
+        getbalance_MP(actorAddress, nonManagedID).balance == zeroAmount
+        getbalance_MP(actorAddress, nonManagedID).reserved == 4.0
+        getbalance_MP(otherAddress, nonManagedID).balance == 6.0
+    }
+
+    def setupSpec() {
+        if (!commandExists("omni_sendall")) {
+            throw new AssumptionViolatedException('The client has no "omni_sendall" command')
+        }
+    }
+
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
@@ -191,7 +191,6 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getbalance_MP(actorAddress, currencyID).balance == new BigDecimal("9223372036854775807")
     }
 
-    @Ignore
     def "Granting more than 9223372036854775807 tokens in total is invalid"() {
         when:
         def txid = grantTokens(actorAddress, currencyID, 1)
@@ -219,7 +218,6 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getbalance_MP(otherAddress, currencyID).balance == new BigDecimal("1")
     }
 
-    @Ignore
     def "Sending of granted tokens does not remove the limit of total tokens"() {
         when:
         def txid = grantTokens(actorAddress, currencyID, 1) // MAX < total + 1 (!)

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -246,6 +246,21 @@ public class OmniClient extends BitcoinClient {
     }
 
     /**
+     * Creates and broadcasts a "send all" transaction.
+     *
+     * @param fromAddress The address to spent from
+     * @param toAddress   The address to send to
+     * @return The hash of the transaction
+     */
+    public Sha256Hash sendAll(Address fromAddress, Address toAddress)
+            throws JsonRPCException, IOException {
+        List<Object> params = createParamList(fromAddress.toString(), toAddress.toString());
+        String txid = send("omni_sendall", params);
+        Sha256Hash hash = Sha256Hash.wrap(txid);
+        return hash;
+    }
+
+    /**
      * Creates and broadcasts a "trade" transaction.
      *
      * @param fromAddress     The address to trade with


### PR DESCRIPTION
Specification:

 - All available tokens can be transferred with transaction type 4
 - "Send All" transactions are only valid, if at least one token was transferred
 - Only available, unreserved balances are transferred with "Send All"

The tests are only executed, if the client has the RPC call "omni_sendall".

Two tests for managed properties were enabled, which are available for Omni Core 0.0.10.

Related: https://github.com/OmniLayer/omnicore/pull/155