### PR TITLE
Add, replace and use Omni Core 0.0.10 RPC API

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/BaseMainNetSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/BaseMainNetSpec.groovy
@@ -48,7 +48,7 @@ abstract class BaseMainNetSpec extends Specification implements OmniClientDelega
         def omniVersion
         def infoMP
         try {
-            infoMP = client.getinfo_MP()
+            infoMP = client.omniGetInfo()
         } catch (JsonRPCStatusException e) {
             /* swallow */
         }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ConsensusSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ConsensusSpec.groovy
@@ -8,7 +8,7 @@ class ConsensusSpec extends BaseRegTestSpec {
 
     def "Check all balances"() {
         when: "we check Omni balances"
-        def balances = getallbalancesforid_MP(MSC)
+        def balances = omniGetAllBalancesForId(MSC)
 
         then: "we get a list of size >= 0"
         balances != null

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ListPropertiesSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ListPropertiesSpec.groovy
@@ -9,13 +9,13 @@ import static foundation.omni.CurrencyID.TMSC
 import foundation.omni.rpc.SmartPropertyListInfo
 
 /**
- * Specification for listproperties_MP
+ * Specification for {@code "omni_listproperties"}.
  */
 class ListPropertiesSpec extends BaseRegTestSpec {
 
     def "Returns a property list with correct MSC and TMSC entries"() {
         when: "we get a list of properties"
-        List<SmartPropertyListInfo> properties = listproperties_MP()
+        List<SmartPropertyListInfo> properties = omniListProperties()
 
         then: "we get a list of size >= 2"
         properties != null

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/OmniSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/OmniSpec.groovy
@@ -10,18 +10,18 @@ import static foundation.omni.CurrencyID.*
  */
 class OmniSpec extends BaseRegTestSpec {
 
-    def "Implement getbalance_MP"() {
-        when: "we call getbalance_MP on a newly generated address"
+    def "Implement omni_getbalance"() {
+        when: "we call omni_getbalance on a newly generated address"
         def destAddr = getNewAddress()                   // Create new Bitcoin address
-        def entry = getbalance_MP(destAddr, MSC)
+        def entry = omniGetBalance(destAddr, MSC)
 
         then: "it should return a balance of zero"
         entry.balance == 0
     }
 
-    def "Return Omni Core version field using getinfo_MP" () {
+    def "Return Omni Core version field using omni_getinfo" () {
         when: "we request info"
-        def mpInfo = getinfo_MP()
+        def mpInfo = omniGetInfo()
 
         then: "we get back an Omni version, too"
         mpInfo != null

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/SendRawTransactionSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/SendRawTransactionSpec.groovy
@@ -23,13 +23,13 @@ class SendRawTransactionSpec extends BaseRegTestSpec {
 
     def "Create raw transaction with reference address"() {
         when: "we submit a raw transaction"
-        def txid = client.sendrawtx_MP(activeAddress, rawTxHex, passiveAddress)
+        def txid = client.omniSendRawTx(activeAddress, rawTxHex, passiveAddress)
 
         and: "a new block is mined"
         client.generateBlock()
 
         then: "the transaction confirms"
-        def transaction = client.getTransactionMP(txid)
+        def transaction = client.omniGetTransaction(txid)
         transaction.confirmations == 1
 
         and: "the transaction should be valid"
@@ -48,13 +48,13 @@ class SendRawTransactionSpec extends BaseRegTestSpec {
 
     def "Create raw transaction without reference address"() {
         when: "we submit a raw transaction"
-        def txid = client.sendrawtx_MP(activeAddress, rawTxHex)
+        def txid = client.omniSendRawTx(activeAddress, rawTxHex)
 
         and: "a new block is mined"
         client.generateBlock()
 
         then: "the transaction confirmed"
-        def transaction = client.getTransactionMP(txid)
+        def transaction = client.omniGetTransaction(txid)
         transaction.confirmations == 1
 
         and: "the transaction should be valid"

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/SimpleSendSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/SimpleSendSpec.groovy
@@ -22,16 +22,16 @@ class SimpleSendSpec extends BaseRegTestSpec {
         def faucetAddress = createFundedAddress(faucetBTC, fundingMSC)
 
         when: "we send MSC"
-        def startBalance = getbalance_MP(faucetAddress, MSC).balance
+        def startBalance = omniGetBalance(faucetAddress, MSC).balance
         def toAddress = getNewAddress()
-        send_MP(faucetAddress, toAddress, MSC, amount)
+        omniSend(faucetAddress, toAddress, MSC, amount)
 
         and: "a block is generated"
         generateBlock()
-        def endBalance = getbalance_MP(faucetAddress, MSC).balance
+        def endBalance = omniGetBalance(faucetAddress, MSC).balance
 
         then: "the toAddress has the correct MSC balance and source address is reduced by right amount"
-        amount == getbalance_MP(toAddress, MSC).balance
+        amount == omniGetBalance(toAddress, MSC).balance
         endBalance == startBalance - amount
 
         where:
@@ -49,7 +49,7 @@ class SimpleSendSpec extends BaseRegTestSpec {
         def toAddress = getNewAddress()
 
         when: "the amount to transfer is zero"
-        send_MP(fundedAddress, toAddress, MSC, 0)
+        omniSend(fundedAddress, toAddress, MSC, 0)
         // TODO: Test sending a negative amount of coins?
         // TODO: Check that the *right type* of exceptions are thrown
         // Currently it seems they're all 500s
@@ -70,7 +70,7 @@ class SimpleSendSpec extends BaseRegTestSpec {
         def toAddress = getNewAddress()
 
         when: "the amount to transfer is zero"
-        send_MP(fundedAddress, toAddress, MSC, -1.0)
+        omniSend(fundedAddress, toAddress, MSC, -1.0)
         // TODO: Test sending a negative amount of coins?
         // TODO: Check that the *right type* of exceptions are thrown
         // Currently it seems they're all 500s
@@ -91,7 +91,7 @@ class SimpleSendSpec extends BaseRegTestSpec {
         def toAddress = getNewAddress()
 
         when: "the sending address has zero coins in its available balance for the specified currency identifier"
-        def txid = client.send_MP(emptyAddress, toAddress, MSC, 1.0)
+        def txid = client.omniSend(emptyAddress, toAddress, MSC, 1.0)
 
         then: "exception is thrown"
         JsonRPCStatusException e = thrown()
@@ -106,7 +106,7 @@ class SimpleSendSpec extends BaseRegTestSpec {
         def toAddress = getNewAddress()
 
         when: "the amount to transfer exceeds the number owned and available by the sending address"
-        send_MP(fundedAddress, toAddress, MSC, 1.00000001)
+        omniSend(fundedAddress, toAddress, MSC, 1.00000001)
 
         then: "exception is thrown"
         JsonRPCStatusException e = thrown()
@@ -121,7 +121,7 @@ class SimpleSendSpec extends BaseRegTestSpec {
         def toAddress = getNewAddress()
 
         when: "the specified currency identifier is non-existent"
-        send_MP(richAddress, toAddress, nonExistentCurrencyID, 1.0)
+        omniSend(richAddress, toAddress, nonExistentCurrencyID, 1.0)
 
         then: "exception is thrown"
         JsonRPCStatusException e = thrown()

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CloseCrowdsaleSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CloseCrowdsaleSpec.groovy
@@ -24,7 +24,7 @@ class CloseCrowdsaleSpec extends BaseRegTestSpec {
         def txid = createCrowdsale(actorAddress, Ecosystem.TMSC, PropertyType.DIVISIBLE, CurrencyID.TMSC, 500000000L,
                                    2147483648L, 0 as Byte, 0 as Byte)
         generateBlock()
-        def creationTx = getTransactionMP(txid)
+        def creationTx = omniGetTransaction(txid)
         assert (creationTx.valid)
         currencyID = new CurrencyID(creationTx.propertyid as Long)
         nonCrowdsaleID = fundNewProperty(actorAddress, 500.0, PropertyType.DIVISIBLE, Ecosystem.TMSC)
@@ -36,7 +36,7 @@ class CloseCrowdsaleSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
     }
 
     def "Closing a non-crowdsale is invalid"() {
@@ -45,7 +45,7 @@ class CloseCrowdsaleSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
     }
 
     def "A crowdsale can not be closed by a non-issuer"() {
@@ -54,27 +54,27 @@ class CloseCrowdsaleSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getcrowdsale_MP(currencyID).active
+        omniGetCrowdsale(currencyID).active
     }
 
     def "Before closing a crowdsale, tokens can be purchased"() {
         when:
-        def txid = send_MP(otherAddress, actorAddress, CurrencyID.TMSC, 0.5)
+        def txid = omniSend(otherAddress, actorAddress, CurrencyID.TMSC, 0.5)
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid
+        omniGetTransaction(txid).valid
 
         and:
-        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == 1.5
-        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == 0.5
+        omniGetBalance(actorAddress, CurrencyID.TMSC).balance == 1.5
+        omniGetBalance(otherAddress, CurrencyID.TMSC).balance == 0.5
 
         and: "tokens were credited to the participant"
-        getbalance_MP(actorAddress, currencyID).balance == 0.0
-        getbalance_MP(otherAddress, currencyID).balance == 2.5
+        omniGetBalance(actorAddress, currencyID).balance == 0.0
+        omniGetBalance(otherAddress, currencyID).balance == 2.5
     }
 
     def "A crowdsale can be closed with transaction type 53"() {
@@ -83,10 +83,10 @@ class CloseCrowdsaleSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid
+        omniGetTransaction(txid).valid
 
         and:
-        getcrowdsale_MP(currencyID).active == false
+        omniGetCrowdsale(currencyID).active == false
     }
 
     def "A crowdsale can only be closed once"() {
@@ -95,24 +95,24 @@ class CloseCrowdsaleSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
     }
 
     def "Sending tokens, after a crowdsale was closed, does not grant tokens"() {
         when:
-        def txid = send_MP(otherAddress, actorAddress, CurrencyID.TMSC, 0.5)
+        def txid = omniSend(otherAddress, actorAddress, CurrencyID.TMSC, 0.5)
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid
+        omniGetTransaction(txid).valid
 
         and:
-        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == 2.0
-        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == 0.0
+        omniGetBalance(actorAddress, CurrencyID.TMSC).balance == 2.0
+        omniGetBalance(otherAddress, CurrencyID.TMSC).balance == 0.0
 
         and: "no tokens were credited to the participant"
-        getbalance_MP(actorAddress, currencyID) == old(getbalance_MP(actorAddress, currencyID))
-        getbalance_MP(otherAddress, currencyID) == old(getbalance_MP(otherAddress, currencyID))
+        omniGetBalance(actorAddress, currencyID) == old(omniGetBalance(actorAddress, currencyID))
+        omniGetBalance(otherAddress, currencyID) == old(omniGetBalance(otherAddress, currencyID))
     }
 
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CrowdsaleParticipationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CrowdsaleParticipationSpec.groovy
@@ -35,26 +35,26 @@ class CrowdsaleParticipationSpec extends BaseRegTestSpec {
         def currencyMSC = CurrencyID.MSC
 
         when: "creating a new crowdsale with 0.00000001 MDiv per unit invested"
-        def crowdsaleTxid = sendrawtx_MP(issuerAddress, rawTx)
+        def crowdsaleTxid = omniSendRawTx(issuerAddress, rawTx)
         generateBlock()
 
         then: "the crowdsale is active"
-        def crowdsaleTx = getTransactionMP(crowdsaleTxid)
+        def crowdsaleTx = omniGetTransaction(crowdsaleTxid)
         crowdsaleTx.confirmations == 1
         crowdsaleTx.valid == true
         def propertyId = new CurrencyID(crowdsaleTx.propertyid as Long)
-        getcrowdsale_MP(propertyId).active == true
+        omniGetCrowdsale(propertyId).active == true
 
         when: "participant invests #amountToInvest MSC"
-        def sendTxid = send_MP(investorAddress, issuerAddress, currencyMSC, amountToInvest)
+        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest)
         generateBlock()
 
         then: "the investor should get #expectedBalance MDiv"
-        getTransactionMP(sendTxid).valid == true
-        getbalance_MP(investorAddress, propertyId).balance == expectedBalance
+        omniGetTransaction(sendTxid).valid == true
+        omniGetBalance(investorAddress, propertyId).balance == expectedBalance
 
         and: "the issuer receives the invested amount"
-        getbalance_MP(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
+        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
 
         where:
         amountToInvest | expectedBalance
@@ -89,26 +89,26 @@ class CrowdsaleParticipationSpec extends BaseRegTestSpec {
         def currencyMSC = CurrencyID.MSC
 
         when: "creating a new crowdsale with 0.00000001 MDiv per unit invested"
-        def crowdsaleTxid = sendrawtx_MP(issuerAddress, rawTx)
+        def crowdsaleTxid = omniSendRawTx(issuerAddress, rawTx)
         generateBlock()
 
         then: "the crowdsale is active"
-        def crowdsaleTx = getTransactionMP(crowdsaleTxid)
+        def crowdsaleTx = omniGetTransaction(crowdsaleTxid)
         crowdsaleTx.confirmations == 1
         crowdsaleTx.valid == true
         def propertyId = new CurrencyID(crowdsaleTx.propertyid as Long)
-        getcrowdsale_MP(propertyId).active == true
+        omniGetCrowdsale(propertyId).active == true
 
         when: "participant invests #amountToInvest MSC"
-        def sendTxid = send_MP(investorAddress, issuerAddress, currencyMSC, amountToInvest)
+        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest)
         generateBlock()
 
         then: "the investor should get #expectedBalance MDiv"
-        getTransactionMP(sendTxid).valid == true
-        getbalance_MP(investorAddress, propertyId).balance == expectedBalance
+        omniGetTransaction(sendTxid).valid == true
+        omniGetBalance(investorAddress, propertyId).balance == expectedBalance
 
         and: "the issuer receives the invested amount"
-        getbalance_MP(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
+        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
 
         where:
         amountToInvest | expectedBalance
@@ -143,26 +143,26 @@ class CrowdsaleParticipationSpec extends BaseRegTestSpec {
         def currencyMSC = CurrencyID.TMSC
 
         when: "creating a new crowdsale with 3400 TIndiv per unit invested"
-        def crowdsaleTxid = sendrawtx_MP(issuerAddress, rawTx)
+        def crowdsaleTxid = omniSendRawTx(issuerAddress, rawTx)
         generateBlock()
 
         then: "the crowdsale is active"
-        def crowdsaleTx = getTransactionMP(crowdsaleTxid)
+        def crowdsaleTx = omniGetTransaction(crowdsaleTxid)
         crowdsaleTx.confirmations == 1
         crowdsaleTx.valid == true
         def propertyId = new CurrencyID(crowdsaleTx.propertyid as Long)
-        getcrowdsale_MP(propertyId).active == true
+        omniGetCrowdsale(propertyId).active == true
 
         when: "participant invests #amountToInvest TMSC"
-        def sendTxid = send_MP(investorAddress, issuerAddress, currencyMSC, amountToInvest)
+        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest)
         generateBlock()
 
         then: "the investor should get #expectedBalance TIndiv"
-        getTransactionMP(sendTxid).valid == true
-        getbalance_MP(investorAddress, propertyId).balance == expectedBalance as BigDecimal
+        omniGetTransaction(sendTxid).valid == true
+        omniGetBalance(investorAddress, propertyId).balance == expectedBalance as BigDecimal
 
         and: "the issuer receives the invested amount"
-        getbalance_MP(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
+        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
 
         where:
         amountToInvest | expectedBalance

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/exodus/MoneyManSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/exodus/MoneyManSpec.groovy
@@ -49,25 +49,25 @@ class MoneyManSpec extends BaseRegTestSpec {
 
         and: "The balances for the account we just sent MSC to is correct"
         getBitcoinBalance(testAddress) == extraAmount
-        getbalance_MP(testAddress, MSC).balance == initialMSCPerBTC * sendAmount
-        getbalance_MP(testAddress, TMSC).balance == initialMSCPerBTC * sendAmount
+        omniGetBalance(testAddress, MSC).balance == initialMSCPerBTC * sendAmount
+        omniGetBalance(testAddress, TMSC).balance == initialMSCPerBTC * sendAmount
     }
 
     def "check Spec setup"() {
         // This test is really an integration test of createFundedAddress()
         expect:
         getBitcoinBalance(faucetAddress) == faucetBTC
-        getbalance_MP(faucetAddress, MSC).balance == initialMSCPerBTC * sendAmount
-        getbalance_MP(faucetAddress, TMSC).balance == initialMSCPerBTC * sendAmount
+        omniGetBalance(faucetAddress, MSC).balance == initialMSCPerBTC * sendAmount
+        omniGetBalance(faucetAddress, TMSC).balance == initialMSCPerBTC * sendAmount
     }
 
     def "Simple send MSC from one address to another" () {
         // This test either duplicates or should be moved to MSCSimpleSendSpec
 
         when: "we send MSC"
-        def senderBalance = getbalance_MP(faucetAddress, MSC)
+        def senderBalance = omniGetBalance(faucetAddress, MSC)
         def toAddress = getNewAddress()
-        def txid = client.send_MP(faucetAddress, toAddress, MSC, simpleSendAmount)
+        def txid = client.omniSend(faucetAddress, toAddress, MSC, simpleSendAmount)
         def tx = client.getTransaction(txid)
 
         then: "we got a non-zero transaction id"
@@ -76,8 +76,8 @@ class MoneyManSpec extends BaseRegTestSpec {
 
         when: "a block is generated"
         generateBlock()
-        def newSenderBalance = client.getbalance_MP(faucetAddress, MSC)
-        def receiverBalance = client.getbalance_MP(toAddress, MSC)
+        def newSenderBalance = client.omniGetBalance(faucetAddress, MSC)
+        def receiverBalance = client.omniGetBalance(toAddress, MSC)
 
         then: "the toAddress has the correct MSC balance and source address is reduced by right amount"
         receiverBalance.balance == simpleSendAmount
@@ -88,15 +88,15 @@ class MoneyManSpec extends BaseRegTestSpec {
         // This test either duplicates or should be moved to MSCSimpleSendSpec
 
         when: "we send MSC"
-        def wealthyBalance = getbalance_MP(faucetAddress, MSC).balance
-        def txid = send_MP(faucetAddress, faucetAddress, MSC, 10.12345678)
+        def wealthyBalance = omniGetBalance(faucetAddress, MSC).balance
+        def txid = omniSend(faucetAddress, faucetAddress, MSC, 10.12345678)
 
         then: "we got a non-zero transaction id"
         txid != OmniClient.zeroHash
 
         when: "a block is generated"
         generateBlock()
-        def newWealthyBalance = getbalance_MP(faucetAddress, MSC).balance
+        def newWealthyBalance = omniGetBalance(faucetAddress, MSC).balance
 
         then: "balance is unchanged"
         newWealthyBalance == wealthyBalance

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
@@ -53,7 +53,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetOrderbook(propertySPX, propertyMSC).size() == 0
 
         and:
-        getbalance_MP(actorC, propertyMSC).reserved == 0.00000001
+        omniGetBalance(actorC, propertyMSC).reserved == 0.00000001
     }
 
     /**
@@ -82,10 +82,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetTrade(txidTradeB).status != "filled"
 
         and:
-        getbalance_MP(actorA, propertyMSC).balance == 0.5
-        getbalance_MP(actorA, propertySPX).reserved == 20 as BigDecimal
-        getbalance_MP(actorB, propertySPX).balance == 5 as BigDecimal
-        getbalance_MP(actorB, propertyMSC).reserved == 0.05
+        omniGetBalance(actorA, propertyMSC).balance == 0.5
+        omniGetBalance(actorA, propertySPX).reserved == 20 as BigDecimal
+        omniGetBalance(actorB, propertySPX).balance == 5 as BigDecimal
+        omniGetBalance(actorB, propertyMSC).reserved == 0.05
     }
 
     /**
@@ -113,10 +113,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetTrade(txidTradeB).status != "filled"
 
         and:
-        getbalance_MP(actorA, propertySPX).balance == 10 as BigDecimal
-        getbalance_MP(actorA, propertyMSC).reserved == 0.0
-        getbalance_MP(actorB, propertyMSC).balance == 0.00000020
-        getbalance_MP(actorB, propertySPX).reserved == 2 as BigDecimal
+        omniGetBalance(actorA, propertySPX).balance == 10 as BigDecimal
+        omniGetBalance(actorA, propertyMSC).reserved == 0.0
+        omniGetBalance(actorB, propertyMSC).balance == 0.00000020
+        omniGetBalance(actorB, propertySPX).reserved == 2 as BigDecimal
     }
 
     /**
@@ -144,10 +144,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetTrade(txidTradeB).status == "filled"
 
         and:
-        getbalance_MP(actorA, propertyMSC).balance == 1.66666666
-        getbalance_MP(actorA, propertySPX).reserved == 0.16666667
-        getbalance_MP(actorB, propertySPX).balance == 0.83333333
-        getbalance_MP(actorB, propertyMSC).reserved == 0.0
+        omniGetBalance(actorA, propertyMSC).balance == 1.66666666
+        omniGetBalance(actorA, propertySPX).reserved == 0.16666667
+        omniGetBalance(actorB, propertySPX).balance == 0.83333333
+        omniGetBalance(actorB, propertyMSC).reserved == 0.0
     }
 
     /**
@@ -175,10 +175,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetTrade(txidTradeB).status == "filled"
 
         and:
-        getbalance_MP(actorA, propertySPX).balance == 50.0
-        getbalance_MP(actorA, propertyMSC).reserved == 11.5
-        getbalance_MP(actorB, propertyMSC).balance == 11.5
-        getbalance_MP(actorB, propertySPX).reserved == 0.0
+        omniGetBalance(actorA, propertySPX).balance == 50.0
+        omniGetBalance(actorA, propertyMSC).reserved == 11.5
+        omniGetBalance(actorB, propertyMSC).balance == 11.5
+        omniGetBalance(actorB, propertySPX).reserved == 0.0
     }
 
     def "One side of the trade must either be MSC or TMSC"() {
@@ -194,10 +194,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetTrade(txidTrade).valid == false
 
         and:
-        getbalance_MP(actorAdress, propertySPA).balance == 20.0
-        getbalance_MP(actorAdress, propertySPB).balance == 10.0
-        getbalance_MP(actorAdress, propertySPA).reserved == zeroAmount
-        getbalance_MP(actorAdress, propertySPB).reserved == zeroAmount
+        omniGetBalance(actorAdress, propertySPA).balance == 20.0
+        omniGetBalance(actorAdress, propertySPB).balance == 10.0
+        omniGetBalance(actorAdress, propertySPA).reserved == zeroAmount
+        omniGetBalance(actorAdress, propertySPB).reserved == zeroAmount
     }
 
     @Unroll
@@ -208,10 +208,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(traderB, amountSPX, propertyTypeSPX, propertyMSC.ecosystem)
 
         then:
-        getbalance_MP(traderA, propertyMSC).balance == amountMSC
-        getbalance_MP(traderA, propertySPX).balance == zeroAmount
-        getbalance_MP(traderB, propertyMSC).balance == zeroAmount
-        getbalance_MP(traderB, propertySPX).balance == amountSPX
+        omniGetBalance(traderA, propertyMSC).balance == amountMSC
+        omniGetBalance(traderA, propertySPX).balance == zeroAmount
+        omniGetBalance(traderB, propertyMSC).balance == zeroAmount
+        omniGetBalance(traderB, propertySPX).balance == amountSPX
 
         when: "trader A offers MSC and desired SPX"
         def txidOfferA = omniSendTrade(traderA, propertyMSC, amountMSC, propertySPX, amountSPX)
@@ -227,8 +227,8 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetOrderbook(propertyMSC, propertySPX).size() == 1
 
         and: "the offered amount is now reserved"
-        getbalance_MP(traderA, propertyMSC).balance == zeroAmount
-        getbalance_MP(traderA, propertyMSC).reserved == amountMSC
+        omniGetBalance(traderA, propertyMSC).balance == zeroAmount
+        omniGetBalance(traderA, propertyMSC).reserved == amountMSC
 
         when: "trader B offers SPX and desires MSC"
         def txidOfferB = omniSendTrade(traderB, propertySPX, amountSPX, propertyMSC, amountMSC)
@@ -244,16 +244,16 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetOrderbook(propertyMSC, propertySPX).size() == 0
 
         and:
-        getbalance_MP(traderA, propertyMSC).balance == zeroAmount
-        getbalance_MP(traderA, propertySPX).balance == amountSPX
-        getbalance_MP(traderB, propertyMSC).balance == amountMSC
-        getbalance_MP(traderB, propertySPX).balance == zeroAmount
+        omniGetBalance(traderA, propertyMSC).balance == zeroAmount
+        omniGetBalance(traderA, propertySPX).balance == amountSPX
+        omniGetBalance(traderB, propertyMSC).balance == amountMSC
+        omniGetBalance(traderB, propertySPX).balance == zeroAmount
 
         and:
-        getbalance_MP(traderA, propertyMSC).reserved == zeroAmount
-        getbalance_MP(traderA, propertySPX).reserved == zeroAmount
-        getbalance_MP(traderB, propertyMSC).reserved == zeroAmount
-        getbalance_MP(traderB, propertySPX).reserved == zeroAmount
+        omniGetBalance(traderA, propertyMSC).reserved == zeroAmount
+        omniGetBalance(traderA, propertySPX).reserved == zeroAmount
+        omniGetBalance(traderB, propertyMSC).reserved == zeroAmount
+        omniGetBalance(traderB, propertySPX).reserved == zeroAmount
 
         where:
         propertyTypeSPX          | amountSPX                              | propertyMSC     | amountMSC
@@ -282,10 +282,10 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(traderA, amountSPX, propertyTypeSPX, propertyMSC.ecosystem)
 
         then:
-        getbalance_MP(traderA, propertyMSC).balance == zeroAmount
-        getbalance_MP(traderA, propertySPX).balance == amountSPX
-        getbalance_MP(traderB, propertyMSC).balance == amountMSC
-        getbalance_MP(traderB, propertySPX).balance == zeroAmount
+        omniGetBalance(traderA, propertyMSC).balance == zeroAmount
+        omniGetBalance(traderA, propertySPX).balance == amountSPX
+        omniGetBalance(traderB, propertyMSC).balance == amountMSC
+        omniGetBalance(traderB, propertySPX).balance == zeroAmount
 
         when: "trader A offers SPX and desired MSC"
         def txidOfferA = omniSendTrade(traderA, propertySPX, amountSPX, propertyMSC, amountMSC)
@@ -301,8 +301,8 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetOrderbook(propertySPX, propertyMSC).size() == 1
 
         and: "the offered amount is now reserved"
-        getbalance_MP(traderA, propertySPX).balance == zeroAmount
-        getbalance_MP(traderA, propertySPX).reserved == amountSPX
+        omniGetBalance(traderA, propertySPX).balance == zeroAmount
+        omniGetBalance(traderA, propertySPX).reserved == amountSPX
 
         when: "trader B offers MSC and desires SPX"
         def txidOfferB = omniSendTrade(traderB, propertyMSC, amountMSC, propertySPX, amountSPX)
@@ -318,16 +318,16 @@ class MetaDexSpec extends BaseRegTestSpec {
         omniGetOrderbook(propertySPX, propertyMSC).size() == 0
 
         and:
-        getbalance_MP(traderA, propertyMSC).balance == amountMSC
-        getbalance_MP(traderA, propertySPX).balance == zeroAmount
-        getbalance_MP(traderB, propertyMSC).balance == zeroAmount
-        getbalance_MP(traderB, propertySPX).balance == amountSPX
+        omniGetBalance(traderA, propertyMSC).balance == amountMSC
+        omniGetBalance(traderA, propertySPX).balance == zeroAmount
+        omniGetBalance(traderB, propertyMSC).balance == zeroAmount
+        omniGetBalance(traderB, propertySPX).balance == amountSPX
 
         and:
-        getbalance_MP(traderA, propertyMSC).reserved == zeroAmount
-        getbalance_MP(traderA, propertySPX).reserved == zeroAmount
-        getbalance_MP(traderB, propertyMSC).reserved == zeroAmount
-        getbalance_MP(traderB, propertySPX).reserved == zeroAmount
+        omniGetBalance(traderA, propertyMSC).reserved == zeroAmount
+        omniGetBalance(traderA, propertySPX).reserved == zeroAmount
+        omniGetBalance(traderB, propertyMSC).reserved == zeroAmount
+        omniGetBalance(traderB, propertySPX).reserved == zeroAmount
 
         where:
         propertyTypeSPX          | amountSPX                              | propertyMSC     | amountMSC

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
@@ -14,7 +14,6 @@ class MetaDexSpec extends BaseRegTestSpec {
 
     final static BigDecimal startBTC = 0.001
     final static BigDecimal zeroAmount = 0.0
-    final static Byte actionNew = 1
 
     /**
      * @see: https://github.com/OmniLayer/omnicore/issues/39
@@ -28,13 +27,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(actorB, 10, PropertyType.INDIVISIBLE, propertyMSC.ecosystem)
 
         when:
-        def txidTradeA = trade_MP(actorA, propertyMSC, 0.00000006 , propertySPX, 6, actionNew)
+        def txidTradeA = omniSendTrade(actorA, propertyMSC, 0.00000006 , propertySPX, 6)
         generateBlock()
-        def txidTradeB = trade_MP(actorB, propertySPX, 10, propertyMSC, 0.00000001, actionNew)
+        def txidTradeB = omniSendTrade(actorB, propertySPX, 10, propertyMSC, 0.00000001)
         generateBlock()
-        def txidTradeC = trade_MP(actorC, propertyMSC, 0.00000001, propertySPX, 10, actionNew)
+        def txidTradeC = omniSendTrade(actorC, propertyMSC, 0.00000001, propertySPX, 10)
         generateBlock()
-        def txidTradeD = trade_MP(actorD, propertyMSC, 0.00000001, propertySPX, 4, actionNew)
+        def txidTradeD = omniSendTrade(actorD, propertyMSC, 0.00000001, propertySPX, 4)
         generateBlock()
 
         then:
@@ -67,9 +66,9 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(actorA, 25, PropertyType.INDIVISIBLE, propertyMSC.ecosystem)
 
         when:
-        def txidTradeA = trade_MP(actorA, propertySPX, 25, propertyMSC, 2.50, actionNew)
+        def txidTradeA = omniSendTrade(actorA, propertySPX, 25, propertyMSC, 2.50)
         generateBlock()
-        def txidTradeB = trade_MP(actorB, propertyMSC, 0.55, propertySPX, 5, actionNew)
+        def txidTradeB = omniSendTrade(actorB, propertyMSC, 0.55, propertySPX, 5)
         generateBlock()
 
         then:
@@ -99,9 +98,9 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(actorB, 12, PropertyType.INDIVISIBLE, propertyMSC.ecosystem)
 
         when:
-        def txidTradeA = trade_MP(actorA, propertyMSC, 0.00000020 , propertySPX, 10, actionNew)
+        def txidTradeA = omniSendTrade(actorA, propertyMSC, 0.00000020 , propertySPX, 10)
         generateBlock()
-        def txidTradeB = trade_MP(actorB, propertySPX, 12, propertyMSC, 0.00000017, actionNew)
+        def txidTradeB = omniSendTrade(actorB, propertySPX, 12, propertyMSC, 0.00000017)
         generateBlock()
 
         then:
@@ -130,9 +129,9 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(actorA, 1.0, PropertyType.DIVISIBLE, propertyMSC.ecosystem)
 
         when:
-        def txidTradeA = trade_MP(actorA, propertySPX, 1.0, propertyMSC, 2.0, actionNew)
+        def txidTradeA = omniSendTrade(actorA, propertySPX, 1.0, propertyMSC, 2.0)
         generateBlock()
-        def txidTradeB = trade_MP(actorB, propertyMSC, 1.66666666, propertySPX, 0.83333333, actionNew)
+        def txidTradeB = omniSendTrade(actorB, propertyMSC, 1.66666666, propertySPX, 0.83333333)
         generateBlock()
 
         then:
@@ -161,9 +160,9 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPX = fundNewProperty(actorB, 50.0, PropertyType.DIVISIBLE, propertyMSC.ecosystem)
 
         when:
-        def txidTradeA = trade_MP(actorA, propertyMSC, 23.0 , propertySPX, 100.0, actionNew)
+        def txidTradeA = omniSendTrade(actorA, propertyMSC, 23.0 , propertySPX, 100.0)
         generateBlock()
-        def txidTradeB = trade_MP(actorB, propertySPX, 50.0, propertyMSC, 10.0, actionNew)
+        def txidTradeB = omniSendTrade(actorB, propertySPX, 50.0, propertyMSC, 10.0)
         generateBlock()
 
         then:
@@ -188,7 +187,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         def propertySPB = fundNewProperty(actorAdress, 10.0, PropertyType.DIVISIBLE, Ecosystem.TMSC)
 
         when:
-        def txidTrade = trade_MP(actorAdress, propertySPA, 1.0, propertySPB, 1.0, actionNew)
+        def txidTrade = omniSendTrade(actorAdress, propertySPA, 1.0, propertySPB, 1.0)
         generateBlock()
 
         then:
@@ -215,7 +214,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         getbalance_MP(traderB, propertySPX).balance == amountSPX
 
         when: "trader A offers MSC and desired SPX"
-        def txidOfferA = trade_MP(traderA, propertyMSC, amountMSC, propertySPX, amountSPX, actionNew)
+        def txidOfferA = omniSendTrade(traderA, propertyMSC, amountMSC, propertySPX, amountSPX)
         generateBlock()
 
         then: "it is a valid open order"
@@ -232,7 +231,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         getbalance_MP(traderA, propertyMSC).reserved == amountMSC
 
         when: "trader B offers SPX and desires MSC"
-        def txidOfferB = trade_MP(traderB, propertySPX, amountSPX, propertyMSC, amountMSC, actionNew)
+        def txidOfferB = omniSendTrade(traderB, propertySPX, amountSPX, propertyMSC, amountMSC)
         generateBlock()
 
         then: "the order is filled"
@@ -289,7 +288,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         getbalance_MP(traderB, propertySPX).balance == zeroAmount
 
         when: "trader A offers SPX and desired MSC"
-        def txidOfferA = trade_MP(traderA, propertySPX, amountSPX, propertyMSC, amountMSC, actionNew)
+        def txidOfferA = omniSendTrade(traderA, propertySPX, amountSPX, propertyMSC, amountMSC)
         generateBlock()
 
         then: "it is a valid open order"
@@ -306,7 +305,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         getbalance_MP(traderA, propertySPX).reserved == amountSPX
 
         when: "trader B offers MSC and desires SPX"
-        def txidOfferB = trade_MP(traderB, propertyMSC, amountMSC, propertySPX, amountSPX, actionNew)
+        def txidOfferB = omniSendTrade(traderB, propertyMSC, amountMSC, propertySPX, amountSPX)
         generateBlock()
 
         then: "the order is filled"
@@ -350,11 +349,11 @@ class MetaDexSpec extends BaseRegTestSpec {
     }
 
     def setupSpec() {
-        if (!commandExists("gettrade_MP")) {
-            throw new AssumptionViolatedException('The client has no "gettrade_MP" command')
+        if (!commandExists("omni_gettrade")) {
+            throw new AssumptionViolatedException('The client has no "omni_gettrade" command')
         }
-        if (!commandExists("getorderbook_MP")) {
-            throw new AssumptionViolatedException('The client has no "getorderbook_MP" command')
+        if (!commandExists("omni_getorderbook")) {
+            throw new AssumptionViolatedException('The client has no "omni_getorderbook" command')
         }
     }
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
@@ -37,20 +37,20 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        gettrade_MP(txidTradeA).valid
-        gettrade_MP(txidTradeB).valid
-        gettrade_MP(txidTradeC).valid
-        gettrade_MP(txidTradeD).valid
+        omniGetTrade(txidTradeA).valid
+        omniGetTrade(txidTradeB).valid
+        omniGetTrade(txidTradeC).valid
+        omniGetTrade(txidTradeD).valid
 
         and:
-        gettrade_MP(txidTradeA).status == "filled"
-        gettrade_MP(txidTradeB).status == "filled"
-        gettrade_MP(txidTradeC).status == "open"
-        gettrade_MP(txidTradeD).status == "filled"
+        omniGetTrade(txidTradeA).status == "filled"
+        omniGetTrade(txidTradeB).status == "filled"
+        omniGetTrade(txidTradeC).status == "open"
+        omniGetTrade(txidTradeD).status == "filled"
 
         and:
-        getorderbook_MP(propertyMSC, propertySPX).size() == 1
-        getorderbook_MP(propertySPX, propertyMSC).size() == 0
+        omniGetOrderbook(propertyMSC, propertySPX).size() == 1
+        omniGetOrderbook(propertySPX, propertyMSC).size() == 0
 
         and:
         getbalance_MP(actorC, propertyMSC).reserved == 0.00000001
@@ -72,14 +72,14 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        gettrade_MP(txidTradeA).valid
-        gettrade_MP(txidTradeB).valid
+        omniGetTrade(txidTradeA).valid
+        omniGetTrade(txidTradeB).valid
 
         and:
-        gettrade_MP(txidTradeA).status != "open"
-        gettrade_MP(txidTradeB).status != "open"
-        gettrade_MP(txidTradeA).status != "filled"
-        gettrade_MP(txidTradeB).status != "filled"
+        omniGetTrade(txidTradeA).status != "open"
+        omniGetTrade(txidTradeB).status != "open"
+        omniGetTrade(txidTradeA).status != "filled"
+        omniGetTrade(txidTradeB).status != "filled"
 
         and:
         getbalance_MP(actorA, propertyMSC).balance == 0.5
@@ -104,13 +104,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        gettrade_MP(txidTradeA).valid
-        gettrade_MP(txidTradeB).valid
+        omniGetTrade(txidTradeA).valid
+        omniGetTrade(txidTradeB).valid
 
         and:
-        gettrade_MP(txidTradeA).status == "filled"
-        gettrade_MP(txidTradeB).status != "open"
-        gettrade_MP(txidTradeB).status != "filled"
+        omniGetTrade(txidTradeA).status == "filled"
+        omniGetTrade(txidTradeB).status != "open"
+        omniGetTrade(txidTradeB).status != "filled"
 
         and:
         getbalance_MP(actorA, propertySPX).balance == 10 as BigDecimal
@@ -135,13 +135,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        gettrade_MP(txidTradeA).valid
-        gettrade_MP(txidTradeB).valid
+        omniGetTrade(txidTradeA).valid
+        omniGetTrade(txidTradeB).valid
 
         and:
-        gettrade_MP(txidTradeA).status != "open"
-        gettrade_MP(txidTradeA).status != "filled"
-        gettrade_MP(txidTradeB).status == "filled"
+        omniGetTrade(txidTradeA).status != "open"
+        omniGetTrade(txidTradeA).status != "filled"
+        omniGetTrade(txidTradeB).status == "filled"
 
         and:
         getbalance_MP(actorA, propertyMSC).balance == 1.66666666
@@ -166,13 +166,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        gettrade_MP(txidTradeA).valid
-        gettrade_MP(txidTradeB).valid
+        omniGetTrade(txidTradeA).valid
+        omniGetTrade(txidTradeB).valid
 
         and:
-        gettrade_MP(txidTradeA).status != "open"
-        gettrade_MP(txidTradeA).status != "filled"
-        gettrade_MP(txidTradeB).status == "filled"
+        omniGetTrade(txidTradeA).status != "open"
+        omniGetTrade(txidTradeA).status != "filled"
+        omniGetTrade(txidTradeB).status == "filled"
 
         and:
         getbalance_MP(actorA, propertySPX).balance == 50.0
@@ -191,7 +191,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        gettrade_MP(txidTrade).valid == false
+        omniGetTrade(txidTrade).valid == false
 
         and:
         getbalance_MP(actorAdress, propertySPA).balance == 20.0
@@ -218,13 +218,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then: "it is a valid open order"
-        gettrade_MP(txidOfferA).valid
-        gettrade_MP(txidOfferA).status == "open"
-        gettrade_MP(txidOfferA).propertyidforsale == propertyMSC.getValue()
-        gettrade_MP(txidOfferA).propertyiddesired == propertySPX.getValue()
+        omniGetTrade(txidOfferA).valid
+        omniGetTrade(txidOfferA).status == "open"
+        omniGetTrade(txidOfferA).propertyidforsale == propertyMSC.getValue()
+        omniGetTrade(txidOfferA).propertyiddesired == propertySPX.getValue()
 
         and: "there is an offering for the new property in the orderbook"
-        getorderbook_MP(propertyMSC, propertySPX).size() == 1
+        omniGetOrderbook(propertyMSC, propertySPX).size() == 1
 
         and: "the offered amount is now reserved"
         getbalance_MP(traderA, propertyMSC).balance == zeroAmount
@@ -235,13 +235,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then: "the order is filled"
-        gettrade_MP(txidOfferB).valid
-        gettrade_MP(txidOfferB).status == "filled"
-        gettrade_MP(txidOfferB).propertyidforsale == propertySPX.getValue()
-        gettrade_MP(txidOfferB).propertyiddesired == propertyMSC.getValue()
+        omniGetTrade(txidOfferB).valid
+        omniGetTrade(txidOfferB).status == "filled"
+        omniGetTrade(txidOfferB).propertyidforsale == propertySPX.getValue()
+        omniGetTrade(txidOfferB).propertyiddesired == propertyMSC.getValue()
 
         and: "the offering is no longer listed in the orderbook"
-        getorderbook_MP(propertyMSC, propertySPX).size() == 0
+        omniGetOrderbook(propertyMSC, propertySPX).size() == 0
 
         and:
         getbalance_MP(traderA, propertyMSC).balance == zeroAmount
@@ -292,13 +292,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then: "it is a valid open order"
-        gettrade_MP(txidOfferA).valid
-        gettrade_MP(txidOfferA).status == "open"
-        gettrade_MP(txidOfferA).propertyidforsale == propertySPX.getValue()
-        gettrade_MP(txidOfferA).propertyiddesired == propertyMSC.getValue()
+        omniGetTrade(txidOfferA).valid
+        omniGetTrade(txidOfferA).status == "open"
+        omniGetTrade(txidOfferA).propertyidforsale == propertySPX.getValue()
+        omniGetTrade(txidOfferA).propertyiddesired == propertyMSC.getValue()
 
         and: "there is an offering for the new property in the orderbook"
-        getorderbook_MP(propertySPX, propertyMSC).size() == 1
+        omniGetOrderbook(propertySPX, propertyMSC).size() == 1
 
         and: "the offered amount is now reserved"
         getbalance_MP(traderA, propertySPX).balance == zeroAmount
@@ -309,13 +309,13 @@ class MetaDexSpec extends BaseRegTestSpec {
         generateBlock()
 
         then: "the order is filled"
-        gettrade_MP(txidOfferB).valid
-        gettrade_MP(txidOfferB).status == "filled"
-        gettrade_MP(txidOfferB).propertyidforsale == propertyMSC.getValue()
-        gettrade_MP(txidOfferB).propertyiddesired == propertySPX.getValue()
+        omniGetTrade(txidOfferB).valid
+        omniGetTrade(txidOfferB).status == "filled"
+        omniGetTrade(txidOfferB).propertyidforsale == propertyMSC.getValue()
+        omniGetTrade(txidOfferB).propertyiddesired == propertySPX.getValue()
 
         and: "the offering is no longer listed in the orderbook"
-        getorderbook_MP(propertySPX, propertyMSC).size() == 0
+        omniGetOrderbook(propertySPX, propertyMSC).size() == 0
 
         and:
         getbalance_MP(traderA, propertyMSC).balance == amountMSC

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/misc/ClientConfigurationAndFundingSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/misc/ClientConfigurationAndFundingSpec.groovy
@@ -12,8 +12,8 @@ class ClientConfigurationAndFundingSpec extends BaseRegTestSpec {
         def pristineAddress = newAddress
 
         def balanceBTC = getBitcoinBalance(pristineAddress, 0, 9999999)
-        def balanceMSC = getbalance_MP(pristineAddress, CurrencyID.MSC)
-        def balanceTMSC = getbalance_MP(pristineAddress, CurrencyID.TMSC)
+        def balanceMSC = omniGetBalance(pristineAddress, CurrencyID.MSC)
+        def balanceTMSC = omniGetBalance(pristineAddress, CurrencyID.TMSC)
 
         expect: "zero balances"
         balanceBTC == 0.0
@@ -138,11 +138,11 @@ class ClientConfigurationAndFundingSpec extends BaseRegTestSpec {
         then:
         getBitcoinBalance(receiverAddress) == 0.0
         getBitcoinBalance(senderAddress) == startBTC
-        getbalance_MP(receiverAddress, CurrencyID.MSC).balance == 0.0
-        getbalance_MP(senderAddress, CurrencyID.MSC).balance == startMSC
+        omniGetBalance(receiverAddress, CurrencyID.MSC).balance == 0.0
+        omniGetBalance(senderAddress, CurrencyID.MSC).balance == startMSC
 
         when:
-        def txid = send_MP(senderAddress, receiverAddress, CurrencyID.MSC, startMSC)
+        def txid = omniSend(senderAddress, receiverAddress, CurrencyID.MSC, startMSC)
         generateBlock()
 
         then:
@@ -150,11 +150,11 @@ class ClientConfigurationAndFundingSpec extends BaseRegTestSpec {
         getBitcoinBalance(senderAddress) == 0.0
 
         and:
-        def sendTx = getTransactionMP(txid)
+        def sendTx = omniGetTransaction(txid)
         sendTx.confirmations == 1
         sendTx.valid == true
-        getbalance_MP(receiverAddress, CurrencyID.MSC).balance == startMSC
-        getbalance_MP(senderAddress, CurrencyID.MSC).balance == 0.0
+        omniGetBalance(receiverAddress, CurrencyID.MSC).balance == startMSC
+        omniGetBalance(senderAddress, CurrencyID.MSC).balance == 0.0
 
         where:
         relayTxFee = stdRelayTxFee
@@ -166,7 +166,7 @@ class ClientConfigurationAndFundingSpec extends BaseRegTestSpec {
     def "Requesting #requestedMSC MSC adds exactly that amount to the receivers MSC balance"() {
         given:
         def fundedAddress = newAddress
-        def balanceAtStart = getbalance_MP(fundedAddress, CurrencyID.MSC)
+        def balanceAtStart = omniGetBalance(fundedAddress, CurrencyID.MSC)
 
         when:
         def txid = requestMSC(fundedAddress, requestedMSC)
@@ -174,7 +174,7 @@ class ClientConfigurationAndFundingSpec extends BaseRegTestSpec {
 
         then:
         def fundingTx = getTransaction(txid)
-        def balanceConfirmed = getbalance_MP(fundedAddress, CurrencyID.MSC)
+        def balanceConfirmed = omniGetBalance(fundedAddress, CurrencyID.MSC)
 
         fundingTx.confirmations > 0
         balanceConfirmed.balance == balanceAtStart.balance + requestedMSC

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/BaseReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/BaseReorgSpec.groovy
@@ -39,7 +39,7 @@ abstract class BaseReorgSpec extends BaseRegTestSpec {
             return false
         }
         try {
-            def transaction = getTransactionMP(txid)
+            def transaction = omniGetTransaction(txid)
             if (transaction.valid != true) {
                 return false
             }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
@@ -20,7 +20,7 @@ class PropertyCreationReorgSpec extends BaseReorgSpec {
     CurrencyID nextTestPropertyID
 
     def setupSpec() {
-        propertyListAtStart = listproperties_MP()
+        propertyListAtStart = omniListProperties()
         def mainProperties = propertyListAtStart.findAll { it.id.ecosystem == Ecosystem.MSC }
         def testProperties = propertyListAtStart.findAll { it.id.ecosystem == Ecosystem.TMSC }
         def lastMainPropertyID = mainProperties.last().id
@@ -52,10 +52,10 @@ class PropertyCreationReorgSpec extends BaseReorgSpec {
         checkTransactionValidity(txid)
 
         and: "a new property was created"
-        listproperties_MP().size() == propertyListAtStart.size() + 1
+        omniListProperties().size() == propertyListAtStart.size() + 1
 
         and: "the created property is in the correct ecosystem"
-        def txCreation = getTransactionMP(txid)
+        def txCreation = omniGetTransaction(txid)
         def currencyID = new CurrencyID(txCreation.propertyid as long)
         currencyID.ecosystem == ecosystem
 
@@ -63,7 +63,7 @@ class PropertyCreationReorgSpec extends BaseReorgSpec {
         currencyID == expectedCurrencyID
 
         and: "the creator was credited with the correct amount of created tokens"
-        getbalance_MP(actorAddress, currencyID).balance == expectedBalance
+        omniGetBalance(actorAddress, currencyID).balance == expectedBalance
 
         when: "invalidating the block and property creation transaction"
         invalidateBlock(blockHashOfCreation)
@@ -74,16 +74,16 @@ class PropertyCreationReorgSpec extends BaseReorgSpec {
         !checkTransactionValidity(txid)
 
         and: "the created property is no longer listed"
-        listproperties_MP().size() == propertyListAtStart.size()
+        omniListProperties().size() == propertyListAtStart.size()
 
         when:
-        getproperty_MP(currencyID)
+        omniGetProperty(currencyID)
 
         then: "no information about the property is available"
         thrown(JsonRPCStatusException)
 
         when:
-        getbalance_MP(actorAddress, currencyID)
+        omniGetBalance(actorAddress, currencyID)
 
         then: "no balance information for the property"
         thrown(JsonRPCStatusException)

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
@@ -14,7 +14,7 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         def dummyOwnerAddress = createFundedAddress(startBTC, startMSC)
 
         when: "broadcasting and confirming a send to owners transaction"
-        def txid = sendToOwnersMP(senderAddress, CurrencyID.TMSC, sendAmount)
+        def txid = omniSendSTO(senderAddress, CurrencyID.TMSC, sendAmount)
         def blockHashOfSend = generateAndGetBlockHash()
 
         then: "the transaction is valid"
@@ -43,37 +43,37 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
 
         def txidCreation = createProperty(senderAddress, ecosystem, propertyType, amountToCreate.longValue())
         generateBlock()
-        def txCreation = getTransactionMP(txidCreation)
+        def txCreation = omniGetTransaction(txidCreation)
         def currencyID = new CurrencyID(txCreation.propertyid as long)
 
         when: "funding the owners with a new property"
-        send_MP(senderAddress, dummyOwnerA, currencyID, new BigDecimal("1"))
-        send_MP(senderAddress, dummyOwnerB, currencyID, new BigDecimal("1"))
-        send_MP(senderAddress, dummyOwnerC, currencyID, new BigDecimal("1"))
+        omniSend(senderAddress, dummyOwnerA, currencyID, new BigDecimal("1"))
+        omniSend(senderAddress, dummyOwnerB, currencyID, new BigDecimal("1"))
+        omniSend(senderAddress, dummyOwnerC, currencyID, new BigDecimal("1"))
         def blockHashOfOwnerFunding = generateAndGetBlockHash()
 
         then: "the owners have some balance"
-        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("1")
-        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("1")
-        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("1")
+        omniGetBalance(dummyOwnerA, currencyID).balance == new BigDecimal("1")
+        omniGetBalance(dummyOwnerB, currencyID).balance == new BigDecimal("1")
+        omniGetBalance(dummyOwnerC, currencyID).balance == new BigDecimal("1")
 
         and: "the sender has less"
-        getbalance_MP(senderAddress, currencyID).balance == new BigDecimal("150")
+        omniGetBalance(senderAddress, currencyID).balance == new BigDecimal("150")
 
         when: "sending to the owners"
-        def txidSTO = sendToOwnersMP(senderAddress, currencyID, new BigDecimal("150"))
+        def txidSTO = omniSendSTO(senderAddress, currencyID, new BigDecimal("150"))
         def blockHashOfSend = generateAndGetBlockHash()
 
         then: "the send to owners transaction is valid"
         checkTransactionValidity(txidSTO)
 
         and: "the owners received the tokens"
-        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("51")
-        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("51")
-        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("51")
+        omniGetBalance(dummyOwnerA, currencyID).balance == new BigDecimal("51")
+        omniGetBalance(dummyOwnerB, currencyID).balance == new BigDecimal("51")
+        omniGetBalance(dummyOwnerC, currencyID).balance == new BigDecimal("51")
 
         and: "the sender has no more tokens"
-        getbalance_MP(senderAddress, currencyID).balance == new BigDecimal("0")
+        omniGetBalance(senderAddress, currencyID).balance == new BigDecimal("0")
 
         when: "invalidating the block and send to owners transaction"
         invalidateBlock(blockHashOfSend)
@@ -84,12 +84,12 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         !checkTransactionValidity(txidSTO)
 
         and: "the owners no longer have the tokens they received"
-        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("1")
-        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("1")
-        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("1")
+        omniGetBalance(dummyOwnerA, currencyID).balance == new BigDecimal("1")
+        omniGetBalance(dummyOwnerB, currencyID).balance == new BigDecimal("1")
+        omniGetBalance(dummyOwnerC, currencyID).balance == new BigDecimal("1")
 
         and: "the sender has the balance from before the send to owners transaction"
-        getbalance_MP(senderAddress, currencyID).balance == new BigDecimal("150")
+        omniGetBalance(senderAddress, currencyID).balance == new BigDecimal("150")
 
         when: "rolling back until before the funding of the owners"
         invalidateBlock(blockHashOfOwnerFunding)
@@ -97,12 +97,12 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         generateBlock()
 
         then: "the owners have no tokens"
-        getbalance_MP(dummyOwnerA, currencyID).balance == new BigDecimal("0")
-        getbalance_MP(dummyOwnerB, currencyID).balance == new BigDecimal("0")
-        getbalance_MP(dummyOwnerC, currencyID).balance == new BigDecimal("0")
+        omniGetBalance(dummyOwnerA, currencyID).balance == new BigDecimal("0")
+        omniGetBalance(dummyOwnerB, currencyID).balance == new BigDecimal("0")
+        omniGetBalance(dummyOwnerC, currencyID).balance == new BigDecimal("0")
 
         and: "the sender has the initial amount that was created"
-        getbalance_MP(senderAddress, currencyID).balance == amountToCreate
+        omniGetBalance(senderAddress, currencyID).balance == amountToCreate
     }
 
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SimpleSendReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SimpleSendReorgSpec.groovy
@@ -14,7 +14,7 @@ class SimpleSendReorgSpec extends BaseReorgSpec {
         def blockCountBeforeSend = getBlockCount()
 
         when: "broadcasting and confirming a simple send"
-        def txid = send_MP(senderAddress, receiverAddress, CurrencyID.MSC, sendAmount)
+        def txid = omniSend(senderAddress, receiverAddress, CurrencyID.MSC, sendAmount)
         def blockHashOfSend = generateAndGetBlockHash()
 
         then: "the transaction is valid"
@@ -42,17 +42,17 @@ class SimpleSendReorgSpec extends BaseReorgSpec {
         def receiverAddress = newAddress
         def senderAddress = createFundedAddress(startBTC, startMSC)
 
-        def balanceBeforeSendActor = getbalance_MP(senderAddress, CurrencyID.MSC)
-        def balanceBeforeSendReceiver = getbalance_MP(receiverAddress, CurrencyID.MSC)
+        def balanceBeforeSendActor = omniGetBalance(senderAddress, CurrencyID.MSC)
+        def balanceBeforeSendReceiver = omniGetBalance(receiverAddress, CurrencyID.MSC)
 
         when: "broadcasting and confirming a simple send"
-        def txid = send_MP(senderAddress, receiverAddress, CurrencyID.MSC, sendAmount)
+        def txid = omniSend(senderAddress, receiverAddress, CurrencyID.MSC, sendAmount)
         def blockHashOfSend = generateAndGetBlockHash()
 
         then: "the transaction is valid and the tokens were transferred"
         checkTransactionValidity(txid)
-        getbalance_MP(senderAddress, CurrencyID.MSC).balance == balanceBeforeSendActor.balance - sendAmount
-        getbalance_MP(receiverAddress, CurrencyID.MSC).balance == balanceBeforeSendReceiver.balance + sendAmount
+        omniGetBalance(senderAddress, CurrencyID.MSC).balance == balanceBeforeSendActor.balance - sendAmount
+        omniGetBalance(receiverAddress, CurrencyID.MSC).balance == balanceBeforeSendReceiver.balance + sendAmount
 
         when: "invalidating the block with the send transaction and after a new block is mined"
         invalidateBlock(blockHashOfSend)
@@ -61,8 +61,8 @@ class SimpleSendReorgSpec extends BaseReorgSpec {
 
         then: "the send transaction is no longer valid and the balances before the send are restored"
         !checkTransactionValidity(txid)
-        getbalance_MP(senderAddress, CurrencyID.MSC) == balanceBeforeSendActor
-        getbalance_MP(receiverAddress, CurrencyID.MSC) == balanceBeforeSendReceiver
+        omniGetBalance(senderAddress, CurrencyID.MSC) == balanceBeforeSendActor
+        omniGetBalance(receiverAddress, CurrencyID.MSC) == balanceBeforeSendReceiver
 
         when: "rolling back all blocks until before the initial funding"
         invalidateBlock(blockHashBeforeFunding)
@@ -70,8 +70,8 @@ class SimpleSendReorgSpec extends BaseReorgSpec {
         generateBlock()
 
         then: "the actors have zero balances"
-        getbalance_MP(senderAddress, CurrencyID.MSC).balance == 0.0
-        getbalance_MP(receiverAddress, CurrencyID.MSC).balance == 0.0
+        omniGetBalance(senderAddress, CurrencyID.MSC).balance == 0.0
+        omniGetBalance(receiverAddress, CurrencyID.MSC).balance == 0.0
     }
 
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
@@ -20,15 +20,15 @@ class SendAllSpec extends BaseRegTestSpec {
         def otherAddress = newAddress
 
         then:
-        getbalance_MP(actorAddress, CurrencyID.MSC).balance == startMSC
-        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == startMSC
-        getbalance_MP(otherAddress, CurrencyID.MSC).balance == zeroAmount
-        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == zeroAmount
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == startMSC
+        omniGetBalance(actorAddress, CurrencyID.TMSC).balance == startMSC
+        omniGetBalance(otherAddress, CurrencyID.MSC).balance == zeroAmount
+        omniGetBalance(otherAddress, CurrencyID.TMSC).balance == zeroAmount
 
         when:
         def sendTxid = omniSendAll(actorAddress, otherAddress, ecosystem)
         generateBlock()
-        def sendTx = getTransactionMP(sendTxid)
+        def sendTx = omniGetTransaction(sendTxid)
 
         then: "the transaction is valid"
         sendTx.valid
@@ -50,15 +50,15 @@ class SendAllSpec extends BaseRegTestSpec {
 
         and:
         if (ecosystem == Ecosystem.MSC) {
-            assert getbalance_MP(actorAddress, CurrencyID.MSC).balance == zeroAmount
-            assert getbalance_MP(actorAddress, CurrencyID.TMSC).balance == startMSC
-            assert getbalance_MP(otherAddress, CurrencyID.MSC).balance == startMSC
-            assert getbalance_MP(otherAddress, CurrencyID.TMSC).balance == zeroAmount
+            assert omniGetBalance(actorAddress, CurrencyID.MSC).balance == zeroAmount
+            assert omniGetBalance(actorAddress, CurrencyID.TMSC).balance == startMSC
+            assert omniGetBalance(otherAddress, CurrencyID.MSC).balance == startMSC
+            assert omniGetBalance(otherAddress, CurrencyID.TMSC).balance == zeroAmount
         } else {
-            assert getbalance_MP(actorAddress, CurrencyID.MSC).balance == startMSC
-            assert getbalance_MP(actorAddress, CurrencyID.TMSC).balance == zeroAmount
-            assert getbalance_MP(otherAddress, CurrencyID.MSC).balance == zeroAmount
-            assert getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
+            assert omniGetBalance(actorAddress, CurrencyID.MSC).balance == startMSC
+            assert omniGetBalance(actorAddress, CurrencyID.TMSC).balance == zeroAmount
+            assert omniGetBalance(otherAddress, CurrencyID.MSC).balance == zeroAmount
+            assert omniGetBalance(otherAddress, CurrencyID.TMSC).balance == startMSC
         }
 
         where:
@@ -70,28 +70,28 @@ class SendAllSpec extends BaseRegTestSpec {
         when:
         def actorAddress = createFundedAddress(startBTC, startMSC)
         def otherAddress = newAddress
-        send_MP(actorAddress, otherAddress, CurrencyID.MSC, startMSC)
-        send_MP(actorAddress, otherAddress, CurrencyID.TMSC, startMSC)
+        omniSend(actorAddress, otherAddress, CurrencyID.MSC, startMSC)
+        omniSend(actorAddress, otherAddress, CurrencyID.TMSC, startMSC)
         generateBlock()
 
         then:
-        getbalance_MP(actorAddress, CurrencyID.MSC).balance == zeroAmount
-        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == zeroAmount
-        getbalance_MP(otherAddress, CurrencyID.MSC).balance == startMSC
-        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        omniGetBalance(actorAddress, CurrencyID.TMSC).balance == zeroAmount
+        omniGetBalance(otherAddress, CurrencyID.MSC).balance == startMSC
+        omniGetBalance(otherAddress, CurrencyID.TMSC).balance == startMSC
 
         when:
         def sendTxid = omniSendAll(actorAddress, otherAddress, ecosystem)
         generateBlock()
 
         then:
-        getTransactionMP(sendTxid).valid == false
+        omniGetTransaction(sendTxid).valid == false
 
         and:
-        getbalance_MP(actorAddress, CurrencyID.MSC).balance == zeroAmount
-        getbalance_MP(actorAddress, CurrencyID.TMSC).balance == zeroAmount
-        getbalance_MP(otherAddress, CurrencyID.MSC).balance == startMSC
-        getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        omniGetBalance(actorAddress, CurrencyID.TMSC).balance == zeroAmount
+        omniGetBalance(otherAddress, CurrencyID.MSC).balance == startMSC
+        omniGetBalance(otherAddress, CurrencyID.TMSC).balance == startMSC
 
         where:
         ecosystem << [Ecosystem.MSC, Ecosystem.TMSC]
@@ -106,29 +106,29 @@ class SendAllSpec extends BaseRegTestSpec {
         def tradeCurrency = new CurrencyID(ecosystem.getValue())
 
         then:
-        getbalance_MP(actorAddress, nonManagedID).balance == 10.0
-        getbalance_MP(otherAddress, nonManagedID).balance == zeroAmount
+        omniGetBalance(actorAddress, nonManagedID).balance == 10.0
+        omniGetBalance(otherAddress, nonManagedID).balance == zeroAmount
 
         when:
         def tradeTxid = omniSendTrade(actorAddress, nonManagedID, 4.0, tradeCurrency, 4.0)
         generateBlock()
-        def tradeTx = getTransactionMP(tradeTxid)
+        def tradeTx = omniGetTransaction(tradeTxid)
 
         then:
         tradeTx.valid
-        getbalance_MP(actorAddress, nonManagedID).balance == 6.0
-        getbalance_MP(actorAddress, nonManagedID).reserved == 4.0
+        omniGetBalance(actorAddress, nonManagedID).balance == 6.0
+        omniGetBalance(actorAddress, nonManagedID).reserved == 4.0
 
         when:
         def sendTxid = omniSendAll(actorAddress, otherAddress, ecosystem)
         generateBlock()
-        def sendTx = getTransactionMP(sendTxid)
+        def sendTx = omniGetTransaction(sendTxid)
 
         then:
         sendTx.valid
-        getbalance_MP(actorAddress, nonManagedID).balance == zeroAmount
-        getbalance_MP(actorAddress, nonManagedID).reserved == 4.0
-        getbalance_MP(otherAddress, nonManagedID).balance == 6.0
+        omniGetBalance(actorAddress, nonManagedID).balance == zeroAmount
+        omniGetBalance(actorAddress, nonManagedID).reserved == 4.0
+        omniGetBalance(otherAddress, nonManagedID).balance == 6.0
 
         where:
         ecosystem << [Ecosystem.MSC, Ecosystem.TMSC]

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
@@ -26,7 +26,7 @@ class SendAllSpec extends BaseRegTestSpec {
         getbalance_MP(otherAddress, CurrencyID.TMSC).balance == zeroAmount
 
         when:
-        def sendTxid = sendAll(actorAddress, otherAddress, ecosystem)
+        def sendTxid = omniSendAll(actorAddress, otherAddress, ecosystem)
         generateBlock()
         def sendTx = getTransactionMP(sendTxid)
 
@@ -81,7 +81,7 @@ class SendAllSpec extends BaseRegTestSpec {
         getbalance_MP(otherAddress, CurrencyID.TMSC).balance == startMSC
 
         when:
-        def sendTxid = sendAll(actorAddress, otherAddress, ecosystem)
+        def sendTxid = omniSendAll(actorAddress, otherAddress, ecosystem)
         generateBlock()
 
         then:
@@ -120,7 +120,7 @@ class SendAllSpec extends BaseRegTestSpec {
         getbalance_MP(actorAddress, nonManagedID).reserved == 4.0
 
         when:
-        def sendTxid = sendAll(actorAddress, otherAddress, ecosystem)
+        def sendTxid = omniSendAll(actorAddress, otherAddress, ecosystem)
         generateBlock()
         def sendTx = getTransactionMP(sendTxid)
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
@@ -110,7 +110,7 @@ class SendAllSpec extends BaseRegTestSpec {
         getbalance_MP(otherAddress, nonManagedID).balance == zeroAmount
 
         when:
-        def tradeTxid = trade_MP(actorAddress, nonManagedID, 4.0, tradeCurrency, 4.0, 1 as Byte)
+        def tradeTxid = omniSendTrade(actorAddress, nonManagedID, 4.0, tradeCurrency, 4.0)
         generateBlock()
         def tradeTx = getTransactionMP(tradeTxid)
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
@@ -34,7 +34,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
                                              "Test Subcategory", "ManagedTokens", "http://www.omnilayer.org",
                                              "This is a test for managed properties")
         generateBlock()
-        def creationTx = getTransactionMP(creationTxid)
+        def creationTx = omniGetTransaction(creationTxid)
         currencyID = new CurrencyID(creationTx.propertyid as Long)
 
         then: "the transaction is valid"
@@ -48,12 +48,12 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         creationTx.amount as Integer == 0
 
         and: "there is a new property"
-        listproperties_MP().size() == old(listproperties_MP().size()) + 1
+        omniListProperties().size() == old(omniListProperties().size()) + 1
     }
 
     def "A managed property has a category, subcategory, name, website and description"() {
         when:
-        def propertyInfo = getproperty_MP(currencyID)
+        def propertyInfo = omniGetProperty(currencyID)
 
         then:
         propertyInfo.propertyid == currencyID.getValue()
@@ -67,15 +67,15 @@ class ManagedPropertySpec extends BaseRegTestSpec {
 
     def "A managed property has no fixed supply and starts with 0 tokens"() {
         when:
-        def propertyInfo = getproperty_MP(currencyID)
+        def propertyInfo = omniGetProperty(currencyID)
 
         then:
         propertyInfo.fixedissuance == false
         propertyInfo.totaltokens as Integer == 0
 
         when:
-        def balanceForId = getallbalancesforid_MP(currencyID)
-        def balanceForAddress = getbalance_MP(actorAddress, currencyID)
+        def balanceForId = omniGetAllBalancesForId(currencyID)
+        def balanceForAddress = omniGetBalance(actorAddress, currencyID)
 
         then:
         balanceForId.size() == 0
@@ -85,7 +85,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
 
     def "A reference to the issuer and creation transaction is available"() {
         when:
-        def propertyInfo = getproperty_MP(currencyID)
+        def propertyInfo = omniGetProperty(currencyID)
 
         then:
         propertyInfo.issuer == actorAddress.toString()
@@ -98,17 +98,17 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).txid == txid.toString()
-        getTransactionMP(txid).valid
-        getTransactionMP(txid).type_int == 55
-        getTransactionMP(txid).propertyid == currencyID.getValue()
-        getTransactionMP(txid).divisible == false
-        getTransactionMP(txid).amount as Integer == 100
+        omniGetTransaction(txid).txid == txid.toString()
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).type_int == 55
+        omniGetTransaction(txid).propertyid == currencyID.getValue()
+        omniGetTransaction(txid).divisible == false
+        omniGetTransaction(txid).amount as Integer == 100
     }
 
     def "Granting tokens increases the total number of tokens"() {
         when:
-        def propertyInfo = getproperty_MP(currencyID)
+        def propertyInfo = omniGetProperty(currencyID)
 
         then:
         propertyInfo.totaltokens as Integer == 100
@@ -116,7 +116,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
 
     def "Granting tokens increases the issuer's balance"() {
         when:
-        def balance = getbalance_MP(actorAddress, currencyID)
+        def balance = omniGetBalance(actorAddress, currencyID)
 
         then:
         balance.balance == 100 as BigDecimal
@@ -129,16 +129,16 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).txid == txid.toString()
-        getTransactionMP(txid).valid
-        getTransactionMP(txid).type_int == 55
-        getTransactionMP(txid).propertyid == currencyID.getValue()
-        getTransactionMP(txid).divisible == false
-        getTransactionMP(txid).amount as Integer == 170
+        omniGetTransaction(txid).txid == txid.toString()
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).type_int == 55
+        omniGetTransaction(txid).propertyid == currencyID.getValue()
+        omniGetTransaction(txid).divisible == false
+        omniGetTransaction(txid).amount as Integer == 170
 
         and:
-        getproperty_MP(currencyID).totaltokens as Integer == 270
-        getbalance_MP(actorAddress, currencyID).balance == 270 as BigDecimal
+        omniGetProperty(currencyID).totaltokens as Integer == 270
+        omniGetBalance(actorAddress, currencyID).balance == 270 as BigDecimal
     }
 
     def "It's impossible to grant tokens for an non-existing property"() {
@@ -147,7 +147,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
     }
 
     def "Granting tokens for a property with fixed supply is invalid"() {
@@ -156,11 +156,11 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(nonManagedID).totaltokens == old(getproperty_MP(nonManagedID)).totaltokens
-        getbalance_MP(actorAddress, nonManagedID) == old(getbalance_MP(actorAddress, nonManagedID))
+        omniGetProperty(nonManagedID).totaltokens == old(omniGetProperty(nonManagedID)).totaltokens
+        omniGetBalance(actorAddress, nonManagedID) == old(omniGetBalance(actorAddress, nonManagedID))
     }
 
     def "Tokens can only be granted by the issuer on record"() {
@@ -169,12 +169,12 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(currencyID).totaltokens as Integer == 270
-        getbalance_MP(actorAddress, currencyID).balance == 270 as BigDecimal
-        getbalance_MP(otherAddress, currencyID).balance == zeroAmount
+        omniGetProperty(currencyID).totaltokens as Integer == 270
+        omniGetBalance(actorAddress, currencyID).balance == 270 as BigDecimal
+        omniGetBalance(otherAddress, currencyID).balance == zeroAmount
     }
 
     def "Up to a total of 9223372036854775807 tokens can be granted"() {
@@ -183,12 +183,12 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid
-        getTransactionMP(txid).amount as Long == new Long("9223372036854775537")
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).amount as Long == new Long("9223372036854775537")
 
         and:
-        getproperty_MP(currencyID).totaltokens as Long == new Long("9223372036854775807")
-        getbalance_MP(actorAddress, currencyID).balance == new BigDecimal("9223372036854775807")
+        omniGetProperty(currencyID).totaltokens as Long == new Long("9223372036854775807")
+        omniGetBalance(actorAddress, currencyID).balance == new BigDecimal("9223372036854775807")
     }
 
     @Ignore
@@ -198,25 +198,25 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(currencyID).totaltokens == old(getproperty_MP(currencyID)).totaltokens
-        getbalance_MP(actorAddress, currencyID) == old(getbalance_MP(actorAddress, currencyID))
+        omniGetProperty(currencyID).totaltokens == old(omniGetProperty(currencyID)).totaltokens
+        omniGetBalance(actorAddress, currencyID) == old(omniGetBalance(actorAddress, currencyID))
     }
 
     def "Granted tokens can be transfered as usual"() {
         when:
-        def txid = send_MP(actorAddress, otherAddress, currencyID, 1)
+        def txid = omniSend(actorAddress, otherAddress, currencyID, 1)
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid
+        omniGetTransaction(txid).valid
 
         and:
-        getproperty_MP(currencyID).totaltokens as Long == new Long("9223372036854775807")
-        getbalance_MP(actorAddress, currencyID).balance == new BigDecimal("9223372036854775806")
-        getbalance_MP(otherAddress, currencyID).balance == new BigDecimal("1")
+        omniGetProperty(currencyID).totaltokens as Long == new Long("9223372036854775807")
+        omniGetBalance(actorAddress, currencyID).balance == new BigDecimal("9223372036854775806")
+        omniGetBalance(otherAddress, currencyID).balance == new BigDecimal("1")
     }
 
     @Ignore
@@ -226,12 +226,12 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(currencyID).totaltokens == old(getproperty_MP(currencyID)).totaltokens
-        getbalance_MP(actorAddress, currencyID) == old(getbalance_MP(actorAddress, currencyID))
-        getbalance_MP(otherAddress, currencyID) == old(getbalance_MP(otherAddress, currencyID))
+        omniGetProperty(currencyID).totaltokens == old(omniGetProperty(currencyID)).totaltokens
+        omniGetBalance(actorAddress, currencyID) == old(omniGetBalance(actorAddress, currencyID))
+        omniGetBalance(otherAddress, currencyID) == old(omniGetBalance(otherAddress, currencyID))
     }
 
     def "Tokens of managed properties can be revoked with transaction type 56"() {
@@ -240,17 +240,17 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).txid == txid.toString()
-        getTransactionMP(txid).valid
-        getTransactionMP(txid).type_int == 56
-        getTransactionMP(txid).propertyid == currencyID.getValue()
-        getTransactionMP(txid).divisible == false
-        getTransactionMP(txid).amount as Long == new Long("9223372036854775805")
+        omniGetTransaction(txid).txid == txid.toString()
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).type_int == 56
+        omniGetTransaction(txid).propertyid == currencyID.getValue()
+        omniGetTransaction(txid).divisible == false
+        omniGetTransaction(txid).amount as Long == new Long("9223372036854775805")
     }
 
     def "Revoking tokens decreases the total number of tokens"() {
         when:
-        def propertyInfo = getproperty_MP(currencyID)
+        def propertyInfo = omniGetProperty(currencyID)
 
         then:
         propertyInfo.totaltokens as Integer == 2
@@ -258,7 +258,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
 
     def "Revoking tokens decreases the issuer's balance"() {
         when:
-        def balance = getbalance_MP(actorAddress, currencyID)
+        def balance = omniGetBalance(actorAddress, currencyID)
 
         then:
         balance.balance == 1 as BigDecimal
@@ -270,7 +270,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
     }
 
     @Ignore
@@ -280,12 +280,12 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(currencyID).totaltokens == old(getproperty_MP(currencyID)).totaltokens
-        getbalance_MP(actorAddress, currencyID) == old(getbalance_MP(actorAddress, currencyID))
-        getbalance_MP(otherAddress, currencyID) == old(getbalance_MP(otherAddress, currencyID))
+        omniGetProperty(currencyID).totaltokens == old(omniGetProperty(currencyID)).totaltokens
+        omniGetBalance(actorAddress, currencyID) == old(omniGetBalance(actorAddress, currencyID))
+        omniGetBalance(otherAddress, currencyID) == old(omniGetBalance(otherAddress, currencyID))
     }
 
     def "Revoking tokens for a property with fixed supply is invalid"() {
@@ -294,11 +294,11 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(nonManagedID).totaltokens == old(getproperty_MP(nonManagedID)).totaltokens
-        getbalance_MP(actorAddress, nonManagedID) == old(getbalance_MP(actorAddress, nonManagedID))
+        omniGetProperty(nonManagedID).totaltokens == old(omniGetProperty(nonManagedID)).totaltokens
+        omniGetBalance(actorAddress, nonManagedID) == old(omniGetBalance(actorAddress, nonManagedID))
     }
 
     def "Revoking more tokens than available is not possible"() {
@@ -307,12 +307,12 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         generateBlock()
 
         then:
-        getTransactionMP(txid).valid == false
+        omniGetTransaction(txid).valid == false
 
         and:
-        getproperty_MP(currencyID).totaltokens == old(getproperty_MP(currencyID)).totaltokens
-        getbalance_MP(actorAddress, currencyID) == old(getbalance_MP(actorAddress, currencyID))
-        getbalance_MP(otherAddress, currencyID) == old(getbalance_MP(otherAddress, currencyID))
+        omniGetProperty(currencyID).totaltokens == old(omniGetProperty(currencyID)).totaltokens
+        omniGetBalance(actorAddress, currencyID) == old(omniGetBalance(actorAddress, currencyID))
+        omniGetBalance(otherAddress, currencyID) == old(omniGetBalance(otherAddress, currencyID))
     }
 
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
@@ -191,6 +191,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getbalance_MP(actorAddress, currencyID).balance == new BigDecimal("9223372036854775807")
     }
 
+    @Ignore
     def "Granting more than 9223372036854775807 tokens in total is invalid"() {
         when:
         def txid = grantTokens(actorAddress, currencyID, 1)
@@ -218,6 +219,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getbalance_MP(otherAddress, currencyID).balance == new BigDecimal("1")
     }
 
+    @Ignore
     def "Sending of granted tokens does not remove the limit of total tokens"() {
         when:
         def txid = grantTokens(actorAddress, currencyID, 1) // MAX < total + 1 (!)

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/SmartPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/SmartPropertySpec.groovy
@@ -33,7 +33,7 @@ class SmartPropertySpec extends BaseRegTestSpec {
         client.generateBlock()
 
         then: "the transaction confirms"
-        def transaction = client.getTransactionMP(txid)
+        def transaction = client.omniGetTransaction(txid)
         transaction.confirmations == 1
 
         and: "it should be valid"
@@ -48,7 +48,7 @@ class SmartPropertySpec extends BaseRegTestSpec {
         transaction.amount == "3.14159265"
 
         and: "this amount was credited to the issuer"
-        def available = getbalance_MP(fundedAddress, propertyId)
+        def available = omniGetBalance(fundedAddress, propertyId)
         available.balance == 3.14159265
     }
 
@@ -60,7 +60,7 @@ class SmartPropertySpec extends BaseRegTestSpec {
         client.generateBlock()
 
         then: "the transaction confirms"
-        def transaction = client.getTransactionMP(txid)
+        def transaction = client.omniGetTransaction(txid)
         transaction.confirmations == 1
 
         and: "it should be valid"
@@ -75,7 +75,7 @@ class SmartPropertySpec extends BaseRegTestSpec {
         transaction.amount == "4815162342"
 
         and: "this amount was credited to the issuer"
-        def available = getbalance_MP(fundedAddress, propertyId)
+        def available = omniGetBalance(fundedAddress, propertyId)
         available.balance == 4815162342L
     }
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToManyOwnersSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToManyOwnersSpec.groovy
@@ -1,7 +1,6 @@
 package foundation.omni.test.rpc.sto
 import org.bitcoinj.core.Address
 import foundation.omni.BaseRegTestSpec
-import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
 import foundation.omni.PropertyType
 import spock.lang.Unroll
@@ -44,8 +43,8 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         def currencySPT = fundNewProperty(actorAddress, fundingSPT, propertyType, Ecosystem.MSC)
 
         // Check funding balances of actor
-        def startingBalanceMSC = getbalance_MP(actorAddress, MSC)
-        def startingBalanceSPT = getbalance_MP(actorAddress, currencySPT)
+        def startingBalanceMSC = omniGetBalance(actorAddress, MSC)
+        def startingBalanceSPT = omniGetBalance(actorAddress, currencySPT)
 
         print "\n"
         println String.format("The actor was funded with: %s MSC", startingBalanceMSC.balance.toPlainString())
@@ -59,7 +58,7 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         for (n in 1..maxN) {
             BigDecimal starting = n * amountStartPerOwner
             owners[n] = newAddress
-            send_MP(actorAddress, owners[n], currencySPT, starting)
+            omniSend(actorAddress, owners[n], currencySPT, starting)
             println String.format("Sending %s SPT to owner #%d ...", starting.toPlainString(), n)
             if (n % 500 == 0) {
                 generateBlock()
@@ -69,8 +68,8 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         generateBlock()
 
         // Check starting balances of actor
-        def reallyBalanceMSC = getbalance_MP(actorAddress, MSC)
-        def reallyBalanceSPT = getbalance_MP(actorAddress, currencySPT)
+        def reallyBalanceMSC = omniGetBalance(actorAddress, MSC)
+        def reallyBalanceSPT = omniGetBalance(actorAddress, currencySPT)
 
         print "\n"
         println String.format("The actor now has: %s MSC and should have %s MSC",
@@ -82,7 +81,7 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         // Check owner balances
         for (n in 1..maxN) {
             def expectedBalanceOwnerSPT = n * amountStartPerOwner
-            def startingBalanceOwnerSPT = getbalance_MP(owners[n], currencySPT)
+            def startingBalanceOwnerSPT = omniGetBalance(owners[n], currencySPT)
 
             println String.format("Owner #%d starts with: %s SPT and should have: %s SPT %s",
                     n, startingBalanceOwnerSPT.balance.toPlainString(), expectedBalanceOwnerSPT.toPlainString(),
@@ -94,13 +93,13 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         print "\n"
 
         // Send to owners
-        def stoTxid = sendToOwnersMP(actorAddress, currencySPT, actorSPT)
+        def stoTxid = omniSendSTO(actorAddress, currencySPT, actorSPT)
         generateBlock()
 
         // Check updated owner balances
         for (n in 1..maxN) {
             def expectedFinalBalanceOwnerSPT = n * (amountStartPerOwner + amountDistributePerOwner)
-            def finalBalanceOwnerSPT = getbalance_MP(owners[n], currencySPT)
+            def finalBalanceOwnerSPT = omniGetBalance(owners[n], currencySPT)
 
             println String.format("Owner #%d ends up with: %s SPT and should have: %s SPT %s",
                     n, finalBalanceOwnerSPT.balance.toPlainString(), expectedFinalBalanceOwnerSPT.toPlainString(),
@@ -108,8 +107,8 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         }
 
         // Check final balances of actor
-        def finalBalanceMSC = getbalance_MP(actorAddress, MSC)
-        def finalBalanceSPT = getbalance_MP(actorAddress, currencySPT)
+        def finalBalanceMSC = omniGetBalance(actorAddress, MSC)
+        def finalBalanceSPT = omniGetBalance(actorAddress, currencySPT)
 
         print "\n"
         println String.format(
@@ -142,8 +141,8 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         def currencySPT = fundNewProperty(actorAddress, fundingSPT, propertyType, Ecosystem.MSC)
 
         // Check funding balances of actor
-        def startingBalanceMSC = getbalance_MP(actorAddress, MSC)
-        def startingBalanceSPT = getbalance_MP(actorAddress, currencySPT)
+        def startingBalanceMSC = omniGetBalance(actorAddress, MSC)
+        def startingBalanceSPT = omniGetBalance(actorAddress, currencySPT)
         assert startingBalanceMSC.balance == actorMSC
         assert startingBalanceSPT.balance == fundingSPT
 
@@ -154,7 +153,7 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         for (n in 1..maxN) {
             BigDecimal starting = n * amountStartPerOwner
             owners[n] = newAddress
-            send_MP(actorAddress, owners[n], currencySPT, starting)
+            omniSend(actorAddress, owners[n], currencySPT, starting)
             if (n % 500 == 0) {
                 generateBlock()
             }
@@ -163,36 +162,36 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         generateBlock()
 
         // Check starting balances of actor
-        def reallyBalanceMSC = getbalance_MP(actorAddress, MSC)
-        def reallyBalanceSPT = getbalance_MP(actorAddress, currencySPT)
+        def reallyBalanceMSC = omniGetBalance(actorAddress, MSC)
+        def reallyBalanceSPT = omniGetBalance(actorAddress, currencySPT)
         assert reallyBalanceMSC.balance == actorMSC
         assert reallyBalanceSPT.balance == actorSPT
 
         // Check owner balances
         for (n in 1..maxN) {
             def expectedBalanceOwnerSPT = n * amountStartPerOwner
-            def startingBalanceOwnerSPT = getbalance_MP(owners[n], currencySPT)
+            def startingBalanceOwnerSPT = omniGetBalance(owners[n], currencySPT)
             assert startingBalanceOwnerSPT.balance == expectedBalanceOwnerSPT
         }
 
         // Send to owners
-        def stoTxid = sendToOwnersMP(actorAddress, currencySPT, actorSPT)
+        def stoTxid = omniSendSTO(actorAddress, currencySPT, actorSPT)
         generateBlock()
 
-        def stoTx = getTransactionMP(stoTxid)
+        def stoTx = omniGetTransaction(stoTxid)
         assert stoTx.valid == true
         assert stoTx.confirmations == 1
 
         // Check updated owner balances
         for (n in 1..maxN) {
             def expectedFinalBalanceOwnerSPT = n * (amountStartPerOwner + amountDistributePerOwner)
-            def finalBalanceOwnerSPT = getbalance_MP(owners[n], currencySPT)
+            def finalBalanceOwnerSPT = omniGetBalance(owners[n], currencySPT)
             assert finalBalanceOwnerSPT.balance == expectedFinalBalanceOwnerSPT
         }
 
         // Check final balances of actor
-        def finalBalanceMSC = getbalance_MP(actorAddress, MSC)
-        def finalBalanceSPT = getbalance_MP(actorAddress, currencySPT)
+        def finalBalanceMSC = omniGetBalance(actorAddress, MSC)
+        def finalBalanceSPT = omniGetBalance(actorAddress, currencySPT)
         assert finalBalanceMSC.balance == 0.0
         assert finalBalanceSPT.balance == 0.0
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersSpec.groovy
@@ -33,17 +33,17 @@ class SendToOwnersSpec extends BaseRegTestSpec {
         def expectedBalance = 0.0
 
         when: "We Send to Owners"
-        def startBalances = getallbalancesforid_MP(currencyID)
-        def startBalanceSender = getbalance_MP(fundedAddress, currencyID).balance
+        def startBalances = omniGetAllBalancesForId(currencyID)
+        def startBalanceSender = omniGetBalance(fundedAddress, currencyID).balance
         def numberOfHolders = startBalances.size()
-        sendToOwnersMP(fundedAddress, currencyID, amountSent)
+        omniSendSTO(fundedAddress, currencyID, amountSent)
 
         and: "We generate a block"
         generateBlock()
 
         // The fee for each receiver is #stoFeePerAddress
         if (numberOfHolders > 1) {
-            def endBalances = getallbalancesforid_MP(currencyID)
+            def endBalances = omniGetAllBalancesForId(currencyID)
             def changedBalances = endBalances - startBalances
             def numberReceivers = changedBalances.size() - 1
             def totalFee = numberReceivers * stoFeePerAddress
@@ -54,7 +54,7 @@ class SendToOwnersSpec extends BaseRegTestSpec {
         }
 
         then: "Our balance has been reduced by amount sent + fees"
-        getbalance_MP(fundedAddress, currencyID).balance == expectedBalance
+        omniGetBalance(fundedAddress, currencyID).balance == expectedBalance
     }
 
     def "STO fails when amount sent is zero"() {
@@ -64,7 +64,7 @@ class SendToOwnersSpec extends BaseRegTestSpec {
         def startBalances = consensusTool.getConsensusSnapshot(currencyID)
 
         when: "We Send to Owners with amount equal zero"
-        sendToOwnersMP(fundedAddress, currencyID, 0.0)
+        omniSendSTO(fundedAddress, currencyID, 0.0)
 
         then: "exception is thrown"
         JsonRPCStatusException e = thrown()

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanRawSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanRawSpec.groovy
@@ -23,7 +23,7 @@ class SendToOwnersTestPlanRawSpec extends SendToOwnersTestPlanSpec {
         }
 
         def rawTxHex = createSendToOwnersHex(currency, numberOfTokens.longValue());
-        def txid = sendrawtx_MP(address, rawTxHex)
+        def txid = omniSendRawTx(address, rawTxHex)
         return txid
     }
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
@@ -56,7 +56,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def ownerIds = 0..<numberOfOwners
         ownerIds.each { owners << newAddress }
         owners = owners.sort { it.toString() }
-        ownerIds.each { send_MP(actorAddress, owners[it], currencySPT, sptAvailableOwners[it]) }
+        ownerIds.each { omniSend(actorAddress, owners[it], currencySPT, sptAvailableOwners[it]) }
         generateBlock()
 
         then: "the actor starts with the correct #currencySPT and #currencyMSC balance"
@@ -74,7 +74,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
 
         then: "the transaction validity is #expectedValidity"
         if (txid != null) {
-            def transaction = getTransactionMP(txid)
+            def transaction = omniGetTransaction(txid)
             assert transaction.valid == expectedValidity
             assert transaction.confirmations == 1
         }
@@ -125,7 +125,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def currencySPT = new CurrencyID(4294967295L) // does not exist
 
         given: "the actor starts with #startMSC #currencyMSC"
-        assert getbalance_MP(actorAddress, currencyMSC).balance == startMSC
+        assert omniGetBalance(actorAddress, currencyMSC).balance == startMSC
 
         when: "#amountSTO is sent to owners of #currencySPT"
         def txid = executeSendToOwners(actorAddress, currencySPT, propertyType, amountSTO, expectException)
@@ -133,13 +133,13 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
 
         then: "the transaction validity is #expectedValidity"
         if (txid != null) {
-            def transaction = getTransactionMP(txid)
+            def transaction = omniGetTransaction(txid)
             assert transaction.valid == expectedValidity
             assert transaction.confirmations == 1
         }
 
         and: "the sender's balance is still the same"
-        getbalance_MP(actorAddress, currencyMSC).balance == startMSC
+        omniGetBalance(actorAddress, currencyMSC).balance == startMSC
     }
 
     def "STO Property ID is 0 - bitcoin"() {
@@ -159,7 +159,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def ownerB = createFundedAddress(btcAvailableOwners, startMSC)
 
         then: "they have a certain amount of tokens and coins"
-        getbalance_MP(actorAddress, currencyMSC).balance == startMSC
+        omniGetBalance(actorAddress, currencyMSC).balance == startMSC
         getBitcoinBalance(actorAddress) == btcAvailable
         getBitcoinBalance(ownerA) == btcAvailableOwners
         getBitcoinBalance(ownerB) == btcAvailableOwners
@@ -170,7 +170,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
 
         then: "the transaction validity is #expectedValidity"
         if (txid != null) {
-            def transaction = getTransactionMP(txid)
+            def transaction = omniGetTransaction(txid)
             assert transaction.valid == expectedValidity
             assert transaction.confirmations == 1
         }
@@ -179,7 +179,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         getBitcoinBalance(actorAddress) >= (btcAvailable - 2 * stdTxFee)
 
         and: "all other balances are still the same"
-        getbalance_MP(actorAddress, currencyMSC).balance == startMSC
+        omniGetBalance(actorAddress, currencyMSC).balance == startMSC
         getBitcoinBalance(ownerA) == btcAvailableOwners
         getBitcoinBalance(ownerB) == btcAvailableOwners
     }
@@ -197,9 +197,9 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def ownerA = createFundedAddress(startBTC, startMSC)
         def ownerB = createFundedAddress(startBTC, startMSC)
 
-        assert getbalance_MP(actorAddress, currencyMSC).balance == startMSC
-        assert getbalance_MP(ownerA, currencyMSC).balance == startMSC
-        assert getbalance_MP(ownerB, currencyMSC).balance == startMSC
+        assert omniGetBalance(actorAddress, currencyMSC).balance == startMSC
+        assert omniGetBalance(ownerA, currencyMSC).balance == startMSC
+        assert omniGetBalance(ownerB, currencyMSC).balance == startMSC
 
         // Create property
         def numberOfTokens = amountSTO
@@ -208,30 +208,30 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         }
         def txidCreation = createProperty(ownerA, ecosystem, propertyType, numberOfTokens.longValue())
         generateBlock()
-        def txCreation = getTransactionMP(txidCreation)
+        def txCreation = omniGetTransaction(txidCreation)
         assert txCreation.valid == true
         assert txCreation.confirmations == 1
         def currencySPT = new CurrencyID(txCreation.propertyid)
 
         // Owner A has the tokens
-        assert getbalance_MP(actorAddress, currencySPT).balance == 0.0
-        assert getbalance_MP(ownerA, currencySPT).balance == amountSTO
-        assert getbalance_MP(ownerB, currencySPT).balance == 0.0
+        assert omniGetBalance(actorAddress, currencySPT).balance == 0.0
+        assert omniGetBalance(ownerA, currencySPT).balance == amountSTO
+        assert omniGetBalance(ownerB, currencySPT).balance == 0.0
 
         // Owner A sends half of the tokens to owner B
-        send_MP(ownerA, ownerB, currencySPT, (amountSTO / 2))
+        omniSend(ownerA, ownerB, currencySPT, (amountSTO / 2))
         generateBlock()
-        assert getbalance_MP(actorAddress, currencySPT).balance == 0.0
-        assert getbalance_MP(ownerA, currencySPT).balance == (amountSTO / 2)
-        assert getbalance_MP(ownerB, currencySPT).balance == (amountSTO / 2)
+        assert omniGetBalance(actorAddress, currencySPT).balance == 0.0
+        assert omniGetBalance(ownerA, currencySPT).balance == (amountSTO / 2)
+        assert omniGetBalance(ownerB, currencySPT).balance == (amountSTO / 2)
 
         // Owner A and B send the tokens to the main actor
-        send_MP(ownerA, actorAddress, currencySPT, (amountSTO / 2))
-        send_MP(ownerB, actorAddress, currencySPT, (amountSTO / 2))
+        omniSend(ownerA, actorAddress, currencySPT, (amountSTO / 2))
+        omniSend(ownerB, actorAddress, currencySPT, (amountSTO / 2))
         generateBlock()
-        assert getbalance_MP(actorAddress, currencySPT).balance == amountSTO
-        assert getbalance_MP(ownerA, currencySPT).balance == 0.0
-        assert getbalance_MP(ownerB, currencySPT).balance == 0.0
+        assert omniGetBalance(actorAddress, currencySPT).balance == amountSTO
+        assert omniGetBalance(ownerA, currencySPT).balance == 0.0
+        assert omniGetBalance(ownerB, currencySPT).balance == 0.0
 
         when: "#amountSTO is sent to owners of #currencySPT"
         def txid = executeSendToOwners(actorAddress, currencySPT, propertyType, amountSTO, expectException)
@@ -239,16 +239,16 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
 
         then: "the transaction validity is #expectedValidity"
         if (txid != null) {
-            def transaction = getTransactionMP(txid)
+            def transaction = omniGetTransaction(txid)
             assert transaction.valid == expectedValidity
             assert transaction.confirmations == 1
         }
 
         and: "all balances still the same"
-        assert getbalance_MP(actorAddress, currencyMSC).balance == startMSC
-        assert getbalance_MP(actorAddress, currencySPT).balance == amountSTO
-        assert getbalance_MP(ownerA, currencySPT).balance == 0.0
-        assert getbalance_MP(ownerB, currencySPT).balance == 0.0
+        assert omniGetBalance(actorAddress, currencyMSC).balance == startMSC
+        assert omniGetBalance(actorAddress, currencySPT).balance == amountSTO
+        assert omniGetBalance(ownerA, currencySPT).balance == 0.0
+        assert omniGetBalance(ownerB, currencySPT).balance == 0.0
     }
 
     def "Owners with similar effictive balances, but different available/reserved ratios, receive the same amount"() {
@@ -263,7 +263,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def expectedValidity = true
         def currencyMSC = new CurrencyID(ecosystem.getValue())
 
-        def numberOfAllOwners = getproperty_MP(currencyMSC).size()
+        def numberOfAllOwners = omniGetProperty(currencyMSC).size()
         if (BTC.btcToSatoshis(startMSC - amountSTO) < (numberOfAllOwners - 1)) {
             throw new org.junit.internal.AssumptionViolatedException("actor may not have enough MSC to pay the fee")
         }
@@ -290,16 +290,16 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
 
         then: "the transaction is valid"
         if (txid != null) {
-            def transaction = getTransactionMP(txid)
+            def transaction = omniGetTransaction(txid)
             assert transaction.valid == expectedValidity
             assert transaction.confirmations == 1
         }
 
         when: "comparing the updated balances after the send"
-        def actorBalance = getbalance_MP(actorAddress, currencyMSC)
-        def ownerBalanceA = getbalance_MP(ownerA, currencyMSC)
-        def ownerBalanceB = getbalance_MP(ownerB, currencyMSC)
-        def ownerBalanceC = getbalance_MP(ownerC, currencyMSC)
+        def actorBalance = omniGetBalance(actorAddress, currencyMSC)
+        def ownerBalanceA = omniGetBalance(ownerA, currencyMSC)
+        def ownerBalanceB = omniGetBalance(ownerB, currencyMSC)
+        def ownerBalanceC = omniGetBalance(ownerC, currencyMSC)
         def amountSpentActor = startMSC - actorBalance.balance
         def amountReceivedOwnerA = ownerBalanceA.balance - (startMSC - reservedOwnerA)
         def amountReceivedOwnerB = ownerBalanceB.balance - (startMSC - reservedOwnerB)
@@ -354,7 +354,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def txid = createProperty(actorAddress, ecosystem, propertyType, numberOfTokens.longValue())
         generateBlock()
 
-        def transaction = getTransactionMP(txid)
+        def transaction = omniGetTransaction(txid)
         assert transaction.valid == true
         assert transaction.confirmations == 1
 
@@ -374,7 +374,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def txid = createDexSellOffer(actorAddress, currency, amount, desiredBTC, blockSpan, commitFee, action)
         generateBlock()
 
-        def transaction = getTransactionMP(txid)
+        def transaction = omniGetTransaction(txid)
         assert transaction.valid == true
         assert transaction.confirmations == 1
     }
@@ -387,7 +387,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         Sha256Hash txid = null
 
         try {
-            txid = sendToOwnersMP(address, currency, amount)
+            txid = omniSendSTO(address, currency, amount)
         } catch(Exception) {
             thrown = true
         }
@@ -413,7 +413,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
      * Short cut to confirm a balance.
      */
     void assertBalance(Address address, CurrencyID currency, def expectedAvailable, def expectedReserved) {
-        def balance = getbalance_MP(address, currency)
+        def balance = omniGetBalance(address, currency)
         assert balance.balance == expectedAvailable
         assert balance.reserved == expectedReserved
     }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/tx/OmniTxBuilderIntegSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/tx/OmniTxBuilderIntegSpec.groovy
@@ -19,7 +19,7 @@ class OmniTxBuilderIntegSpec extends BaseRegTestSpec {
     def "Can simple send amount MSC from one address to another using OmniTxBuilder and sendraw RPC"() {
         given: "a fundedAddress with BTC/MSC and a newly created toAddress"
         def fundedAddress = createFundedAddress(startBTC, startMSC)
-        def startBalance = getbalance_MP(fundedAddress, MSC).balance
+        def startBalance = omniGetBalance(fundedAddress, MSC).balance
         def fundedKey = dumpPrivKey(fundedAddress)
         def toAddress = getNewAddress()
         List<TransactionOutput> utxos = listUnspentJ(fundedAddress)
@@ -33,10 +33,10 @@ class OmniTxBuilderIntegSpec extends BaseRegTestSpec {
 
         and: "a block is generated"
         generateBlock()
-        def endBalance = getbalance_MP(fundedAddress, MSC).balance
+        def endBalance = omniGetBalance(fundedAddress, MSC).balance
 
         then: "the toAddress has the correct MSC balance and source address is reduced by correct amount"
-        amount == getbalance_MP(toAddress, MSC).balance
+        amount == omniGetBalance(toAddress, MSC).balance
         endBalance == startBalance - amount
     }
 }

--- a/omnij-rpc/src/main/groovy/foundation/omni/consensus/OmniCoreConsensusTool.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/consensus/OmniCoreConsensusTool.groovy
@@ -56,7 +56,7 @@ class OmniCoreConsensusTool extends ConsensusTool {
     }
 
     private SortedMap<Address, ConsensusEntry> getConsensusForCurrency(CurrencyID currencyID) {
-        List<MPBalanceEntry> balances = client.getallbalancesforid_MP(currencyID)
+        List<MPBalanceEntry> balances = client.omniGetAllBalancesForId(currencyID)
 
         TreeMap<Address, ConsensusEntry> map = [:]
 
@@ -84,13 +84,13 @@ class OmniCoreConsensusTool extends ConsensusTool {
     @Override
     @TypeChecked
     List<SmartPropertyListInfo> listProperties() {
-        List<SmartPropertyListInfo> props = client.listproperties_MP()
+        List<SmartPropertyListInfo> props = client.omniListProperties()
         return props
     }
 
     @Override
     public ConsensusSnapshot getConsensusSnapshot(CurrencyID currencyID) {
-        /* Since getallbalancesforid_MP doesn't return the blockHeight, we have to check
+        /* Since omni_getallbalancesforid doesn't return the blockHeight, we have to check
          * blockHeight before and after the call to make sure it didn't change.
          */
         Integer beforeBlockHeight = currentBlockHeight()

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -97,4 +97,13 @@ trait OmniTestSupport implements BTCTestSupport, OmniClientDelegate, RawTxDelega
         return new CurrencyID(txCreation.propertyid as long)
     }
 
+    CurrencyID fundManagedProperty(Address address, PropertyType type, Ecosystem ecosystem) {
+        def txidCreation = createManagedProperty(address, ecosystem, type, "", "", "MSP", "", "")
+        generateBlock()
+        def txCreation = getTransactionMP(txidCreation)
+        assert txCreation.valid == true
+        assert txCreation.confirmations == 1
+        return new CurrencyID(txCreation.propertyid as long)
+    }
+
 }

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -55,8 +55,8 @@ trait OmniTestSupport implements BTCTestSupport, OmniClientDelegate, RawTxDelega
             def junkAddress = newAddress
 
             // TODO: can we always get away with not generating a block inbetween?
-            def extraTxidMSC = send_MP(toAddress, junkAddress, CurrencyID.MSC, excessiveMSC)
-            def extraTxidTMSC = send_MP(toAddress, junkAddress, CurrencyID.TMSC, excessiveMSC)
+            def extraTxidMSC = omniSend(toAddress, junkAddress, CurrencyID.MSC, excessiveMSC)
+            def extraTxidTMSC = omniSend(toAddress, junkAddress, CurrencyID.TMSC, excessiveMSC)
         }
 
         // TODO: when using an intermediate receiver, this txid doesn't reflect the whole picture
@@ -91,7 +91,7 @@ trait OmniTestSupport implements BTCTestSupport, OmniClientDelegate, RawTxDelega
         OmniValue amount = OmniValue.of(amountBD, type);
         def txidCreation = createProperty(address, ecosystem, type, amount.asWillets())
         generateBlock()
-        def txCreation = getTransactionMP(txidCreation)
+        def txCreation = omniGetTransaction(txidCreation)
         assert txCreation.valid == true
         assert txCreation.confirmations == 1
         return new CurrencyID(txCreation.propertyid as long)
@@ -100,7 +100,7 @@ trait OmniTestSupport implements BTCTestSupport, OmniClientDelegate, RawTxDelega
     CurrencyID fundManagedProperty(Address address, PropertyType type, Ecosystem ecosystem) {
         def txidCreation = createManagedProperty(address, ecosystem, type, "", "", "MSP", "", "")
         generateBlock()
-        def txCreation = getTransactionMP(txidCreation)
+        def txCreation = omniGetTransaction(txidCreation)
         assert txCreation.valid == true
         assert txCreation.confirmations == 1
         return new CurrencyID(txCreation.propertyid as long)

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/MPBalanceEntry.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/MPBalanceEntry.java
@@ -7,7 +7,7 @@ import java.math.BigDecimal;
 /**
  * Balance data for a specific Omni CurrencyID in a single Bitcoin address
  *
- * A Java representation of the JSON entry returned by getallbalancesforid_MP
+ * A Java representation of the JSON entry returned by {@code "omni_getallbalancesforid"}.
  */
 public class MPBalanceEntry {
     private Address address;

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-// TODO: rename methods
-
 // TODO: add missing RPCs:
 // - listtransactions_MP
 // - getsto_MP
@@ -79,7 +77,7 @@ public class OmniClient extends BitcoinClient {
      *
      * @return An object with state information
      */
-    public Map<String, Object> getinfo_MP() throws JsonRPCException, IOException {
+    public Map<String, Object> omniGetInfo() throws JsonRPCException, IOException {
         Map<String, Object> result = send("getinfo_MP", null);
         return result;
     }
@@ -89,7 +87,7 @@ public class OmniClient extends BitcoinClient {
      *
      * @return A list with short information
      */
-    public List<SmartPropertyListInfo> listproperties_MP() throws JsonRPCException, IOException {
+    public List<SmartPropertyListInfo> omniListProperties() throws JsonRPCException, IOException {
         List<Map<String, Object>> result = send("listproperties_MP", null);
 
         List<SmartPropertyListInfo> propList = new ArrayList<SmartPropertyListInfo>();
@@ -121,7 +119,7 @@ public class OmniClient extends BitcoinClient {
      * @param currency The identifier to look up
      * @return An object with detailed information
      */
-    public Map<String, Object> getproperty_MP(CurrencyID currency) throws JsonRPCException, IOException {
+    public Map<String, Object> omniGetProperty(CurrencyID currency) throws JsonRPCException, IOException {
         List<Object> params = createParamList(currency.getValue());
         Map<String, Object> result = send("getproperty_MP", params);
         return result;
@@ -133,7 +131,7 @@ public class OmniClient extends BitcoinClient {
      * @param currency The identifier of the crowdsale
      * @return An object with detailed information
      */
-    public Map<String, Object> getcrowdsale_MP(CurrencyID currency) throws JsonRPCException, IOException {
+    public Map<String, Object> omniGetCrowdsale(CurrencyID currency) throws JsonRPCException, IOException {
         List<Object> params = createParamList(currency.getValue());
         Map<String, Object> result = send("getcrowdsale_MP", params);
         return result;
@@ -154,7 +152,7 @@ public class OmniClient extends BitcoinClient {
      *
      * @return A list with information about the active offers
      */
-    public List<Map<String, Object>> getactivedexsells_MP() throws JsonRPCException, IOException {
+    public List<Map<String, Object>> omniGetActiveDExSells() throws JsonRPCException, IOException {
         List<Map<String, Object>> result = send("getactivedexsells_MP", null);
         return result;
     }
@@ -166,7 +164,7 @@ public class OmniClient extends BitcoinClient {
      * @param currency The identifier of the token to look up
      * @return The available and reserved balance
      */
-    public MPBalanceEntry getbalance_MP(Address address, CurrencyID currency)
+    public MPBalanceEntry omniGetBalance(Address address, CurrencyID currency)
             throws JsonRPCException, IOException, ParseException {
         List<Object> params = createParamList(address.toString(), currency.getValue());
         Map<String, String> result = send("getbalance_MP", params);
@@ -182,7 +180,7 @@ public class OmniClient extends BitcoinClient {
      * @param currency The identifier of the token to look up
      * @return A list containing addresses, and the associated available and reserved balances
      */
-    public List<MPBalanceEntry> getallbalancesforid_MP(CurrencyID currency)
+    public List<MPBalanceEntry> omniGetAllBalancesForId(CurrencyID currency)
             throws JsonRPCException, IOException, ParseException, AddressFormatException {
         List<Object> params = createParamList(currency.getValue());
         List<Map<String, Object>> untypedBalances = send("getallbalancesforid_MP", params);
@@ -254,7 +252,7 @@ public class OmniClient extends BitcoinClient {
      * @param txid The hash of the transaction to look up
      * @return Information about the transaction
      */
-    public Map<String, Object> getTransactionMP(Sha256Hash txid) throws JsonRPCException, IOException {
+    public Map<String, Object> omniGetTransaction(Sha256Hash txid) throws JsonRPCException, IOException {
         List<Object> params = createParamList(txid.toString());
         Map<String, Object> transaction = send("gettransaction_MP", params);
         return transaction;
@@ -284,8 +282,8 @@ public class OmniClient extends BitcoinClient {
      * @param rawTxHex    The hex-encoded raw transaction
      * @return The hash of the transaction
      */
-    public Sha256Hash sendrawtx_MP(Address fromAddress, String rawTxHex) throws JsonRPCException, IOException {
-        return sendrawtx_MP(fromAddress, rawTxHex, null);
+    public Sha256Hash omniSendRawTx(Address fromAddress, String rawTxHex) throws JsonRPCException, IOException {
+        return omniSendRawTx(fromAddress, rawTxHex, null);
     }
 
     /**
@@ -296,7 +294,7 @@ public class OmniClient extends BitcoinClient {
      * @param referenceAddress The reference address
      * @return The hash of the transaction
      */
-    public Sha256Hash sendrawtx_MP(Address fromAddress, String rawTxHex, Address referenceAddress)
+    public Sha256Hash omniSendRawTx(Address fromAddress, String rawTxHex, Address referenceAddress)
             throws JsonRPCException, IOException {
         List<Object> params = createParamList(fromAddress.toString(), rawTxHex);
         if (referenceAddress != null) {
@@ -315,7 +313,7 @@ public class OmniClient extends BitcoinClient {
      * @param amount      The amount to transfer
      * @return The hash of the transaction
      */
-    public Sha256Hash send_MP(Address fromAddress, Address toAddress, CurrencyID currency, BigDecimal amount)
+    public Sha256Hash omniSend(Address fromAddress, Address toAddress, CurrencyID currency, BigDecimal amount)
             throws JsonRPCException, IOException {
         List<Object> params = createParamList(fromAddress.toString(), toAddress.toString(), currency.getValue(),
                                               amount.toPlainString());
@@ -332,7 +330,7 @@ public class OmniClient extends BitcoinClient {
      * @param amount      The amount to distribute
      * @return The hash of the transaction
      */
-    public Sha256Hash sendToOwnersMP(Address fromAddress, CurrencyID currency, BigDecimal amount)
+    public Sha256Hash omniSendSTO(Address fromAddress, CurrencyID currency, BigDecimal amount)
             throws JsonRPCException, IOException {
         List<Object> params = createParamList(fromAddress.toString(), currency.getValue(), amount.toPlainString());
         String txid = send("sendtoowners_MP", params);

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -349,7 +349,7 @@ public class OmniClient extends BitcoinClient {
      * @return The hash of the transaction
      * @since Omni Core 0.0.10
      */
-    public Sha256Hash sendAll(Address fromAddress, Address toAddress, Ecosystem ecosystem)
+    public Sha256Hash omniSendAll(Address fromAddress, Address toAddress, Ecosystem ecosystem)
             throws JsonRPCException, IOException {
         List<Object> params = createParamList(fromAddress.toString(), toAddress.toString(), ecosystem.getValue());
         String txid = send("omni_sendall", params);
@@ -646,9 +646,9 @@ public class OmniClient extends BitcoinClient {
      * @return Information about the order, trade, and order matches
      * @since Omni Core 0.0.10
      */
-    public Map<String, Object> gettrade_MP(Sha256Hash txid) throws JsonRPCException, IOException {
+    public Map<String, Object> omniGetTrade(Sha256Hash txid) throws JsonRPCException, IOException {
         List<Object> params = createParamList(txid.toString());
-        Map<String, Object> trade = send("gettrade_MP", params);
+        Map<String, Object> trade = send("omni_gettrade", params);
         return trade;
     }
 
@@ -659,9 +659,9 @@ public class OmniClient extends BitcoinClient {
      * @return A list of orders
      * @since Omni Core 0.0.10
      */
-    public List<Map<String, Object>> getorderbook_MP(CurrencyID propertyForSale) throws JsonRPCException, IOException {
+    public List<Map<String, Object>> omniGetOrderbook(CurrencyID propertyForSale) throws JsonRPCException, IOException {
         List<Object> params = createParamList(propertyForSale.getValue());
-        List<Map<String, Object>> orders = send("getorderbook_MP", params);
+        List<Map<String, Object>> orders = send("omni_getorderbook", params);
         return orders;
     }
 
@@ -673,10 +673,10 @@ public class OmniClient extends BitcoinClient {
      * @return A list of orders
      * @since Omni Core 0.0.10
      */
-    public List<Map<String, Object>> getorderbook_MP(CurrencyID propertyForSale, CurrencyID propertyDesired)
+    public List<Map<String, Object>> omniGetOrderbook(CurrencyID propertyForSale, CurrencyID propertyDesired)
             throws JsonRPCException, IOException {
         List<Object> params = createParamList(propertyForSale.getValue(), propertyDesired.getValue());
-        List<Map<String, Object>> orders = send("getorderbook_MP", params);
+        List<Map<String, Object>> orders = send("omni_getorderbook", params);
         return orders;
     }
 

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -404,26 +404,22 @@ public class OmniClient extends BitcoinClient {
     }
 
     /**
-     * Creates and broadcasts a "trade" transaction.
-     *
-     * TODO: replace with omniSendTrade
+     * Place a trade offer on the distributed token exchange.
      *
      * @param fromAddress     The address to trade with
-     * @param propertyForSale The property for sale
-     * @param amountForSale   The amount to trade
-     * @param propertyDesired The desired property
-     * @param amountDesired   The desired amount for the trade
-     * @param action          New offer (1), cancel offer (2), cancel offers with currency pair (3), cancel all (4)
+     * @param propertyForSale The identifier of the tokens to list for sale
+     * @param amountForSale   The amount of tokens to list for sale
+     * @param propertyDesired The identifier of the tokens desired in exchange
+     * @param amountDesired   The amount of tokens desired in exchange
      * @return The hash of the transaction
      * @since Omni Core 0.0.10
      */
-    public Sha256Hash trade_MP(Address fromAddress, CurrencyID propertyForSale, BigDecimal amountForSale,
-                               CurrencyID propertyDesired, BigDecimal amountDesired, Byte action)
+    public Sha256Hash omniSendTrade(Address fromAddress, CurrencyID propertyForSale, BigDecimal amountForSale,
+                                    CurrencyID propertyDesired, BigDecimal amountDesired)
             throws JsonRPCException, IOException {
         List<Object> params = createParamList(fromAddress.toString(), propertyForSale.getValue(),
-                                              amountForSale.toPlainString(), propertyDesired.getValue(),
-                                              amountDesired.toPlainString(), action);
-        String txid = send("trade_MP", params);
+                amountForSale.toPlainString(), propertyDesired.getValue(), amountDesired.toPlainString());
+        String txid = send("omni_sendtrade", params);
         Sha256Hash hash = Sha256Hash.wrap(txid);
         return hash;
     }

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
@@ -20,7 +20,7 @@ import java.net.URI;
  * OmniClient that adds "extended" methods for Omni transactions that lack
  * RPCs in Omni Core 0.9.0
  *
- * <p>Raw transactions are created and sent via sendrawtx_MP
+ * <p>Raw transactions are created and sent via {@code "sendrawtx_MP"}.
  *
  */
 public class OmniExtendedClient extends OmniClient {
@@ -43,7 +43,7 @@ public class OmniExtendedClient extends OmniClient {
      */
     public Sha256Hash sendToOwners(Address address, CurrencyID currencyId, Long amount) throws JsonRPCException, IOException {
         String rawTxHex = builder.createSendToOwnersHex(currencyId, amount);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -67,7 +67,7 @@ public class OmniExtendedClient extends OmniClient {
         Coin satoshisFee = BTC.btcToCoin(commitmentFee);
         String rawTxHex = builder.createDexSellOfferHex(
                 currencyId, quantityForSale.asWillets(), satoshisDesired.value, paymentWindow, satoshisFee.value, action);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -84,7 +84,7 @@ public class OmniExtendedClient extends OmniClient {
             throws JsonRPCException, IOException {
         OmniDivisibleValue quantity = OmniDivisibleValue.of(amount);
         String rawTxHex = builder.createAcceptDexOfferHex(currencyId, quantity.asWillets());
-        Sha256Hash txid = sendrawtx_MP(fromAddress, rawTxHex, toAddress);
+        Sha256Hash txid = omniSendRawTx(fromAddress, rawTxHex, toAddress);
         return txid;
     }
 
@@ -109,7 +109,7 @@ public class OmniExtendedClient extends OmniClient {
         OmniDivisibleValue qtyDesired = OmniDivisibleValue.of(amountDesired);  // Assume divisible property
         String rawTxHex = builder.createMetaDexSellOfferHex(
                 currencyForSale, qtyForSale.asWillets(), currencyDesired, qtyDesired.asWillets(), action);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -132,7 +132,7 @@ public class OmniExtendedClient extends OmniClient {
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createCrowdsaleHex(ecosystem, propertyType, 0L, "", "", "CS", "", "", propertyDesired,
                                                      tokensPerUnit, deadline, earlyBirdBonus, issuerBonus);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -163,7 +163,7 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash createProperty(Address address, Ecosystem ecosystem, PropertyType type, Long amount, String label)
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createPropertyHex(ecosystem, type, 0L, "", "", label, "", "", amount);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -176,7 +176,7 @@ public class OmniExtendedClient extends OmniClient {
      */
     public Sha256Hash closeCrowdsale(Address address, CurrencyID currencyID) throws JsonRPCException, IOException {
         String rawTxHex = builder.createCloseCrowdsaleHex(currencyID);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -198,7 +198,7 @@ public class OmniExtendedClient extends OmniClient {
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createManagedPropertyHex(ecosystem, type, 0L, category, subCategory, label, website,
                                                            info);
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -213,7 +213,7 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash grantTokens(Address address, CurrencyID currencyID, Long amount)
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createGrantTokensHex(currencyID, amount, "");
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -228,7 +228,7 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash revokeTokens(Address address, CurrencyID currencyID, Long amount)
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createRevokeTokensHex(currencyID, amount, "");
-        Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
+        Sha256Hash txid = omniSendRawTx(address, rawTxHex);
         return txid;
     }
 
@@ -243,7 +243,7 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash changeIssuer(Address fromAddress, CurrencyID currencyID, Address toAddress)
             throws JsonRPCException, IOException {
         String rawTxHex = builder.createChangePropertyManagerHex(currencyID);
-        Sha256Hash txid = sendrawtx_MP(fromAddress, rawTxHex, toAddress);
+        Sha256Hash txid = omniSendRawTx(fromAddress, rawTxHex, toAddress);
         return txid;
     }
 

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/SmartPropertyListInfo.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/SmartPropertyListInfo.java
@@ -3,7 +3,7 @@ package foundation.omni.rpc;
 import foundation.omni.CurrencyID;
 
 /**
- * Result for a single property from listproperties_MP
+ * Result for a single property from {@code "omni_listproperties"}
  */
 public class SmartPropertyListInfo {
     private final CurrencyID  id;               // propertyid in JSON


### PR DESCRIPTION
This PR adds a bunch of new methods, and updates already existing methods, to access the Omni Core RPC API:

- https://github.com/OmniLayer/omnicore/blob/omnicore-0.0.10/src/omnicore/doc/rpc-api.md

If the RPC is `"omni_getbalance"`, then the corresponding method name is `omniGetBalance()`, if the RPC is `"omni_senddexsell"`, then the method name is `omniSendDExSell()` and so on.