### PR TITLE
Refactoring of several Number and enum-style classes

### DIFF
--- a/bitcoin-rpc/src/integ/groovy/com/msgilligan/bitcoinj/WalletSendSpec.groovy
+++ b/bitcoin-rpc/src/integ/groovy/com/msgilligan/bitcoinj/WalletSendSpec.groovy
@@ -70,7 +70,7 @@ class WalletSendSpec extends BaseRegTestSpec {
 
         then: "the coins arrive"
         client.getReceivedByAddress(walletAddr) == amount
-        wallet.getBalance().longValue() == BTC.btcToSatoshis(amount).longValue()
+        wallet.getBalance() == BTC.btcToCoin(amount)
     }
 
     def "Send from BitcoinJ wallet to the Bitcoin Core wallet"() {
@@ -91,7 +91,7 @@ class WalletSendSpec extends BaseRegTestSpec {
 
         then: "the new address has a balance of amount"
         getReceivedByAddress(rpcAddress) == amount
-        wallet.getBalance().longValue() == BTC.btcToSatoshis(startAmount) - BTC.btcToSatoshis(amount) - Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.longValue()
+        wallet.getBalance() == BTC.btcToCoin(startAmount) - BTC.btcToCoin(amount) - Transaction.REFERENCE_DEFAULT_MIN_TX_FEE
     }
 
     def "create and send a transaction from BitcoinJ using wallet.completeTx"() {

--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/BTC.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/BTC.java
@@ -4,29 +4,36 @@ import org.bitcoinj.core.Coin;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.MathContext;
 
 /**
- * Utility class for converting from satoshis (BigInteger) to bitcoins (BigDecimal) and vice-versa
+ * Utility class for converting BTC (BigDecimal) to satoshis (Coin class)
  */
 public class BTC  {
-    public static final long satoshisPerBitcoin = 100000000;
-    public static final BigInteger satoshisPerBTC = BigInteger.valueOf(satoshisPerBitcoin);
-    public static final BigDecimal satoshisPerBTCDecimal = new BigDecimal(satoshisPerBTC);
+    private static final BigDecimal satoshisPerBTCDecimal = new BigDecimal(Coin.COIN.value);
 
-    public static BigDecimal satoshisToBTC(BigInteger satoshis) {
-        BigDecimal decimalSatoshis = new BigDecimal(satoshis);
-        return decimalSatoshis.divide(satoshisPerBTCDecimal);
-    }
-    public static BigInteger btcToSatoshis(BigDecimal btc) {
+    private static long btcToSatoshisLong(final BigDecimal btc) {
         BigDecimal satoshisDecimal = btc.multiply(BTC.satoshisPerBTCDecimal);
-        return satoshisDecimal.toBigInteger();
+        return satoshisDecimal.longValueExact();
     }
-    public static Coin btcToCoin(BigDecimal btc) {
-        return Coin.valueOf(BTC.btcToSatoshis(btc).longValue());
+
+    /**
+     * Convert from BigDecimal BTC value to Satoshis <code>BigInteger</code>.
+     * @param btc
+     * @return
+     * @deprecated Use {@link BTC#btcToCoin(BigDecimal)}.
+     */
+    @Deprecated
+    public static BigInteger btcToSatoshis(final BigDecimal btc) {
+        return BigInteger.valueOf(btcToSatoshisLong(btc));
     }
-    public static BigDecimal coinToBTC(Coin coin) {
-        BigInteger satoshis = BigInteger.valueOf(coin.longValue());
-        return BTC.satoshisToBTC(satoshis);
+
+    /**
+     * Convert from BigDecimal BTC value to <code>Coin</code> type.
+     *
+     * @param btc Bitcoin amount in BTC units
+     * @return bitcoinj <code>Coin</code> type (uses Satoshis internally)
+     */
+    public static Coin btcToCoin(final BigDecimal btc) {
+        return Coin.valueOf(btcToSatoshisLong(btc));
     }
 }

--- a/omnij-core/src/main/java/foundation/omni/CurrencyID.java
+++ b/omnij-core/src/main/java/foundation/omni/CurrencyID.java
@@ -62,7 +62,7 @@ public final class CurrencyID implements Cloneable {
         }
     }
 
-    public long longValue() {
+    public long getValue() {
         return value;
     }
 

--- a/omnij-core/src/main/java/foundation/omni/Ecosystem.java
+++ b/omnij-core/src/main/java/foundation/omni/Ecosystem.java
@@ -1,9 +1,11 @@
 package foundation.omni;
 
 /**
- * Number type to represent a Omni Protocol Ecosystem
+ * Type to represent Omni Protocol Ecosystem
+ *
+ * TODO: Should Ecosystem be made an enum?
  */
-public class Ecosystem extends Number {
+public class Ecosystem {
     private final short value;
 
     public static final short   MIN_VALUE = 1;
@@ -15,34 +17,18 @@ public class Ecosystem extends Number {
     public static final Ecosystem   MSC = new Ecosystem(MSC_VALUE);
     public static final Ecosystem   TMSC = new Ecosystem(TMSC_VALUE);
 
-    public Ecosystem(int value) {
+    private Ecosystem(short value) {
         if (value < MIN_VALUE) {
             throw new NumberFormatException();
         }
         if (value > MAX_VALUE) {
             throw new NumberFormatException();
         }
-        this.value = (short) value;
+        this.value = value;
     }
 
-    @Override
-    public int intValue() {
-        return (int) value;
-    }
-
-    @Override
-    public long longValue() {
-        return (long) value;
-    }
-
-    @Override
-    public float floatValue() {
-        throw new UnsupportedOperationException("Operation not supported");
-    }
-
-    @Override
-    public double doubleValue() {
-        throw new UnsupportedOperationException("Operation not supported");
+    public short getValue() {
+        return value;
     }
 
     @Override

--- a/omnij-core/src/main/java/foundation/omni/OmniDivisibleValue.java
+++ b/omnij-core/src/main/java/foundation/omni/OmniDivisibleValue.java
@@ -1,5 +1,7 @@
 package foundation.omni;
 
+import org.bitcoinj.core.Coin;
+
 import javax.money.NumberValue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -7,13 +9,33 @@ import java.math.MathContext;
 
 /**
  * Numeric Value of Divisible Omni Token
+ * An Omni Divisible token is typically represented to the user as a decimal amount and hence
+ * you can have a fractional number of tokens. Internally it uses the same format as a divisible token.
+ *
  */
-public class OmniDivisibleValue extends OmniValue {
+public final class OmniDivisibleValue extends OmniValue {
     public static final BigDecimal   MIN_VALUE = new BigDecimal(0); // Minimum value of 1 in transactions?
     public static final BigDecimal   MAX_VALUE = new BigDecimal("92233720368.54775807");
-    public static final long willetsPerCoin = 100000000; // 10^8
-    private static final BigInteger biWilletsPerCoin = BigInteger.valueOf(willetsPerCoin);
+    public static final long willetsPerCoin = Coin.COIN.value; // 10^8 (Omni equivalent of Satoshis
     private static final BigDecimal bdWilletsPerCoin = new BigDecimal(willetsPerCoin);
+
+    /**
+     * Create OmniDivisibleValue of the specified amount
+     * @param amount Number of Omni tokens
+     * @return
+     */
+    public static OmniDivisibleValue of(long amount) {
+        return OmniDivisibleValue.of(BigDecimal.valueOf(amount));
+    }
+
+    /**
+     * Create OmniDivisibleValue of the specified amount
+     * @param amount Number of Omni tokens
+     * @return
+     */
+    public static OmniDivisibleValue of(BigDecimal amount) {
+        return new OmniDivisibleValue(amount.multiply(bdWilletsPerCoin).longValueExact());
+    }
 
     /**
      * Create OmniDivisibleValue from willets/internal/wire format
@@ -21,30 +43,13 @@ public class OmniDivisibleValue extends OmniValue {
      * @param willets number of willets
      * @return OmniIndivisibleValue equal to number of willets
      */
-    public static OmniDivisibleValue fromWillets(long willets) {
-        return new OmniDivisibleValue(willets, true);
+    public static OmniDivisibleValue ofWillets(long willets) {
+        return new OmniDivisibleValue(willets);
     }
 
-    public OmniDivisibleValue(long value) {
-        this(BigInteger.valueOf(value));
-    }
 
-    public OmniDivisibleValue(BigInteger value) {
-        super(value.multiply(biWilletsPerCoin));
-    }
-
-    public OmniDivisibleValue(BigDecimal value) {
-        super(value.multiply(bdWilletsPerCoin).longValueExact());
-    }
-
-    /**
-     * This is a hidden mechanism to implement the fromWillets static method.
-     *
-     * @param number initial value in willets or in coins
-     * @param internalFormat true if number is internal/willets/"wire" format
-     */
-    private OmniDivisibleValue(long number, boolean internalFormat) {
-        super(internalFormat ? number : number * willetsPerCoin);
+    private OmniDivisibleValue(long value) {
+        super(value);
     }
 
     @Override
@@ -144,6 +149,7 @@ public class OmniDivisibleValue extends OmniValue {
 
     public BigDecimal bigDecimalValue() {
         BigDecimal willets = new BigDecimal(value);
+        //TODO: Add rounding mode?
         return willets.divide(bdWilletsPerCoin);
     }
 }

--- a/omnij-core/src/main/java/foundation/omni/OmniIndivisibleValue.java
+++ b/omnij-core/src/main/java/foundation/omni/OmniIndivisibleValue.java
@@ -4,10 +4,21 @@ import java.math.BigInteger;
 
 /**
  * Numeric Value of Indivisible Omni Token
+ * An indivsible token is an integer number of tokens that can't be subdivided to
+ * less than one token.
  */
-public class OmniIndivisibleValue extends OmniValue {
+public final class OmniIndivisibleValue extends OmniValue {
     public static final long   MIN_VALUE = 0; // Minimum value of 1 in transactions?
     public static final long   MAX_VALUE = 9223372036854775807L;
+
+    /**
+     * Create OmniDivisibleValue of the specified amount
+     * @param amount Number of Omni tokens
+     * @return
+     */
+    public static OmniIndivisibleValue of(long amount) {
+        return new OmniIndivisibleValue(amount);
+    }
 
     /**
      * Create OmniIndivisibleValue from willets/internal/wire format
@@ -15,14 +26,11 @@ public class OmniIndivisibleValue extends OmniValue {
      * @param willets number of willets
      * @return OmniIndivisibleValue equal to number of willets
      */
-    public static OmniIndivisibleValue fromWillets(long willets) {
-        return new OmniIndivisibleValue(willets);
+    public static OmniIndivisibleValue ofWillets(long willets) {
+        return OmniIndivisibleValue.of(willets);
     }
 
-    public OmniIndivisibleValue(long value) {
-        super(value);
-    }
-    public OmniIndivisibleValue(BigInteger value) {
+    private OmniIndivisibleValue(long value) {
         super(value);
     }
 }

--- a/omnij-core/src/main/java/foundation/omni/OmniValue.java
+++ b/omnij-core/src/main/java/foundation/omni/OmniValue.java
@@ -1,17 +1,28 @@
 package foundation.omni;
 
 import javax.money.NumberValue;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
 
 /**
- * <p>Numeric Value of Omni Token - base class for divisible and indivisible subclasses.</p>
+ * <p>Numeric value for a quantity of Omni tokens - base class for OmniDivisible and OmniIndivisible subclasses.
+ * Known as "Number of Coins" in the Omni Protocol Specification.</p>
  *
- * <p>Known as "Number of Coins" in the Specification</p>
+ * <p>The internal representation is a <code>long</code> which </code> corresponds to what we call a
+ * "willet" in honour of J.R. Willet in the same fashion as the smallest Bitcoin unit is called a "satoshi".</p>
  *
- * <p>Placeholder: Do not use - not ready yet!</p>
+ * <p>The constructors are <code>protected</code> and instances should be created with the <code>of()</code>
+ * static methods which can take either <code>BigDecimal</code> or <code>long</code> values as parameters.</p>
  *
- * <p>TODO: Implement (all?) unsupported methods</p>
+ * <p>The various *<code>value()</code> methods of <code>Number</code> and <code>NumberValue</code> will
+ * return values as used in the Omni Protocol Specification, which means that <bold>for divisible tokens the
+ * values will be treated a decimal values and methods returning integer types will be throw exceptions if their
+ * is a fractional component that would be truncated.</bold></p>
+ *
+ * <p>TODO: provide examples of *value() methods and what they return</p>
+ *
+ * <p>TODO: Implement unsupported methods</p>
  * <p>TODO: Should we allow negative values?</p>
  */
 public abstract class OmniValue extends NumberValue {
@@ -21,28 +32,49 @@ public abstract class OmniValue extends NumberValue {
     public static final long   MIN_VALUE = 0; // Minimum value of 1 in transactions?
     public static final long   MAX_VALUE = Long.MAX_VALUE; // = 2^63 - 1 = 9223372036854775807L;
 
-    public OmniValue(long value) {
+    /**
+     * Default Constructor
+     * Used only by subclasses using internal (willets) format
+     *
+     * @param value Willets (internal/wire format)
+     */
+    protected OmniValue(long value) {
         checkValue(value);
         this.value = value;
     }
 
-    public OmniValue(BigInteger value) {
+    @Deprecated
+    protected OmniValue(BigInteger value) {
         checkValue(value);
         this.value = value.longValue();
+    }
+
+    public static OmniValue of(BigDecimal amount, PropertyType type) {
+        return type.equals(PropertyType.DIVISIBLE) ?
+                OmniDivisibleValue.of(amount) : OmniIndivisibleValue.of(amount.longValueExact());
+    }
+
+    public static OmniValue of(long amount, PropertyType type) {
+        return type.equals(PropertyType.DIVISIBLE) ?
+                OmniDivisibleValue.of(amount) : OmniIndivisibleValue.of(amount);
+    }
+
+    public long asWillets() {
+        return value;
     }
 
     /**
      * <p>Make sure a BigInteger value is a valid Omni "number of coins" value</p>
      *
      * @param value
-     * @throws NumberFormatException
+     * @throws ArithmeticException
      */
-    public static void checkValue(BigInteger value) throws NumberFormatException {
+    public static void checkValue(BigInteger value) throws ArithmeticException {
         if (value.compareTo(BigInteger.valueOf(MIN_VALUE)) == -1) {
-            throw new NumberFormatException();
+            throw new ArithmeticException();
         }
         if (value.compareTo(BigInteger.valueOf(MAX_VALUE)) == 1) {
-            throw new NumberFormatException();
+            throw new ArithmeticException();
         }
     }
 
@@ -53,11 +85,11 @@ public abstract class OmniValue extends NumberValue {
      * it's not less than MIN_VALUE</p>
      *
      * @param value value to check.
-     * @throws NumberFormatException
+     * @throws ArithmeticException
      */
-    public static void checkValue(long value) throws NumberFormatException {
+    public static void checkValue(long value) throws ArithmeticException {
         if (value < MIN_VALUE) {
-            throw new NumberFormatException();
+            throw new ArithmeticException();
         }
     }
 

--- a/omnij-core/src/main/java/foundation/omni/OmniValue.java
+++ b/omnij-core/src/main/java/foundation/omni/OmniValue.java
@@ -9,7 +9,7 @@ import java.math.MathContext;
  * <p>Numeric value for a quantity of Omni tokens - base class for OmniDivisible and OmniIndivisible subclasses.
  * Known as "Number of Coins" in the Omni Protocol Specification.</p>
  *
- * <p>The internal representation is a <code>long</code> which </code> corresponds to what we call a
+ * <p>The internal representation is a <code>long</code> which corresponds to what we call a
  * "willet" in honour of J.R. Willet in the same fashion as the smallest Bitcoin unit is called a "satoshi".</p>
  *
  * <p>The constructors are <code>protected</code> and instances should be created with the <code>of()</code>

--- a/omnij-core/src/main/java/foundation/omni/PropertyType.java
+++ b/omnij-core/src/main/java/foundation/omni/PropertyType.java
@@ -1,9 +1,11 @@
 package foundation.omni;
 
 /**
- * Number type to represent an Omni protocol property type.
+ * Omni Protocol Property Type.
+ *
+ * TODO: Should PropertyType be made an enum?
  */
-public class PropertyType extends Number {
+public class PropertyType {
     private final int value;
 
     public static final int INDIVISIBLE_VALUE = 1;
@@ -12,7 +14,7 @@ public class PropertyType extends Number {
     public static final PropertyType INDIVISIBLE = new PropertyType(INDIVISIBLE_VALUE);
     public static final PropertyType DIVISIBLE = new PropertyType(DIVISIBLE_VALUE);
 
-    public PropertyType(int value) {
+    private PropertyType(int value) {
         if (!(value == INDIVISIBLE_VALUE ||
               value == DIVISIBLE_VALUE)) {
             throw new NumberFormatException();
@@ -20,24 +22,8 @@ public class PropertyType extends Number {
         this.value = value;
     }
 
-    @Override
-    public int intValue() {
+    public int getValue() {
         return value;
-    }
-
-    @Override
-    public long longValue() {
-        return (long) value;
-    }
-
-    @Override
-    public float floatValue() {
-        throw new UnsupportedOperationException("Operation not supported");
-    }
-
-    @Override
-    public double doubleValue() {
-        throw new UnsupportedOperationException("Operation not supported");
     }
 
     @Override

--- a/omnij-core/src/main/java/foundation/omni/tx/RawTxBuilder.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/RawTxBuilder.java
@@ -19,7 +19,7 @@ public class RawTxBuilder {
      * Creates a hex-encoded raw transaction of type 0: "simple send".
      */
     public String createSimpleSendHex(CurrencyID currencyId, Long amount) {
-        String rawTxHex = String.format("00000000%08x%016x", currencyId.longValue(), amount);
+        String rawTxHex = String.format("00000000%08x%016x", currencyId.getValue(), amount);
         return rawTxHex;
     }
 
@@ -27,7 +27,7 @@ public class RawTxBuilder {
      * Creates a hex-encoded raw transaction of type 3: "send to owners".
      */
     public String createSendToOwnersHex(CurrencyID currencyId, Long amount) {
-        String rawTxHex = String.format("00000003%08x%016x", currencyId.longValue(), amount);
+        String rawTxHex = String.format("00000003%08x%016x", currencyId.getValue(), amount);
         return rawTxHex;
     }
 
@@ -47,7 +47,7 @@ public class RawTxBuilder {
     public String createDexSellOfferHex(CurrencyID currencyId, Long amountForSale, Long amountDesired,
                                         Byte paymentWindow, Long commitmentFee, Byte action) {
         String rawTxHex = String.format("00010014%08x%016x%016x%02x%016x%02x",
-                currencyId.longValue(),
+                currencyId.getValue(),
                 amountForSale,
                 amountDesired,
                 paymentWindow.byteValue(),
@@ -62,9 +62,9 @@ public class RawTxBuilder {
     public String createMetaDexSellOfferHex(CurrencyID currencyForSale, Long amountForSale, CurrencyID currencyDesired,
                                             Long amountDesired, Byte action) {
         String rawTxHex = String.format("00000015%08x%016x%08x%016x%02x",
-                currencyForSale.longValue(),
+                currencyForSale.getValue(),
                 amountForSale,
-                currencyDesired.longValue(),
+                currencyDesired.getValue(),
                 amountDesired,
                 action.byteValue());
         return rawTxHex;
@@ -75,7 +75,7 @@ public class RawTxBuilder {
      */
     public String createAcceptDexOfferHex(CurrencyID currencyId, Long amount) {
         String rawTxHex = String.format("00000016%08x%016x",
-                currencyId.longValue(),
+                currencyId.getValue(),
                 amount);
         return rawTxHex;
     }
@@ -87,8 +87,8 @@ public class RawTxBuilder {
                                     String category, String subCategory, String label, String website, String info,
                                     Long amount) {
         String rawTxHex = String.format("00000032%02x%04x%08x%s00%s00%s00%s00%s00%016x",
-                ecosystem.byteValue(),
-                propertyType.intValue(),
+                ecosystem.getValue(),
+                propertyType.getValue(),
                 previousPropertyId,
                 toHexString(category),
                 toHexString(subCategory),
@@ -107,15 +107,15 @@ public class RawTxBuilder {
                                      CurrencyID propertyDesired, Long tokensPerUnit, Long deadline, Byte earlyBirdBonus,
                                      Byte issuerBonus) {
         String rawTxHex = String.format("00000033%02x%04x%08x%s00%s00%s00%s00%s00%08x%016x%016x%02x%02x",
-                ecosystem.byteValue(),
-                propertyType.intValue(),
+                ecosystem.getValue(),
+                propertyType.getValue(),
                 previousPropertyId,
                 toHexString(category),
                 toHexString(subCategory),
                 toHexString(label),
                 toHexString(website),
                 toHexString(info),
-                propertyDesired.longValue(),
+                propertyDesired.getValue(),
                 tokensPerUnit,
                 deadline,
                 earlyBirdBonus.byteValue(),
@@ -127,7 +127,7 @@ public class RawTxBuilder {
      * Creates a hex-encoded raw transaction of type 53: "close a crowdsale manually".
      */
     public String createCloseCrowdsaleHex(CurrencyID currencyId) {
-        String rawTxHex = String.format("00000035%08x", currencyId.longValue());
+        String rawTxHex = String.format("00000035%08x", currencyId.getValue());
         return rawTxHex;
     }
 
@@ -138,8 +138,8 @@ public class RawTxBuilder {
                                            String category, String subCategory, String label, String website,
                                            String info) {
         String rawTxHex = String.format("00000036%02x%04x%08x%s00%s00%s00%s00%s00",
-                ecosystem.byteValue(),
-                propertyType.intValue(),
+                ecosystem.getValue(),
+                propertyType.getValue(),
                 previousPropertyId,
                 toHexString(category),
                 toHexString(subCategory),
@@ -153,7 +153,7 @@ public class RawTxBuilder {
      * Creates a hex-encoded raw transaction of type 55: "grant tokens for a managed property".
      */
     public String createGrantTokensHex(CurrencyID currencyId, Long amount, String memo) {
-        String rawTxHex = String.format("00000037%08x%016x%s00", currencyId.longValue(), amount, toHexString(memo));
+        String rawTxHex = String.format("00000037%08x%016x%s00", currencyId.getValue(), amount, toHexString(memo));
         return rawTxHex;
     }
 
@@ -161,7 +161,7 @@ public class RawTxBuilder {
      * Creates a hex-encoded raw transaction of type 56: "revoke tokens of a managed property".
      */
     public String createRevokeTokensHex(CurrencyID currencyId, Long amount, String memo) {
-        String rawTxHex = String.format("00000038%08x%016x%s00", currencyId.longValue(), amount, toHexString(memo));
+        String rawTxHex = String.format("00000038%08x%016x%s00", currencyId.getValue(), amount, toHexString(memo));
         return rawTxHex;
     }
 
@@ -169,7 +169,7 @@ public class RawTxBuilder {
      * Creates a hex-encoded raw transaction of type 70: "change manager of a managed property".
      */
     public String createChangePropertyManagerHex(CurrencyID currencyId) {
-        String rawTxHex = String.format("00000046%08x", currencyId.longValue());
+        String rawTxHex = String.format("00000046%08x", currencyId.getValue());
         return rawTxHex;
     }
 

--- a/omnij-core/src/test/groovy/foundation/omni/CurrencyIDSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/CurrencyIDSpec.groovy
@@ -13,8 +13,8 @@ class CurrencyIDSpec extends Specification {
 
         then: "the value is 1"
         currency == CurrencyID.MSC
-        currency.longValue() == CurrencyID.MSC_VALUE
-        currency.longValue() == 1L
+        currency.getValue() == CurrencyID.MSC_VALUE
+        currency.getValue() == 1L
 
         and: "it is in the right ecosystem"
         currency.ecosystem == Ecosystem.MSC
@@ -26,8 +26,8 @@ class CurrencyIDSpec extends Specification {
 
         then: "the value is 2"
         currency == CurrencyID.TMSC
-        currency.longValue() == CurrencyID.TMSC_VALUE
-        currency.longValue() == 2L
+        currency.getValue() == CurrencyID.TMSC_VALUE
+        currency.getValue() == 2L
 
         and: "it is in the right ecosystem"
         currency.ecosystem == Ecosystem.TMSC
@@ -57,7 +57,7 @@ class CurrencyIDSpec extends Specification {
         CurrencyID currencyID = new CurrencyID(id)
 
         then: "it is created correctly"
-        currencyID.longValue() == 1
+        currencyID.getValue() == 1
 
         where:
         id << [1 as Short, 1, 1I, 1L]
@@ -69,7 +69,7 @@ class CurrencyIDSpec extends Specification {
         CurrencyID currencyID = new CurrencyID(id)
 
         then: "it is created correctly"
-        currencyID.longValue() == longValue
+        currencyID.getValue() == longValue
 
         and: "class was as expected"
         id.class == idClass
@@ -153,7 +153,7 @@ class CurrencyIDSpec extends Specification {
 
         expect:
         CurrencyID currency = CurrencyID.valueOf(str)
-        currency.longValue() == value
+        currency.getValue() == value
 
         where:
         str            | value

--- a/omnij-core/src/test/groovy/foundation/omni/EcosystemSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/EcosystemSpec.groovy
@@ -10,37 +10,22 @@ class EcosystemSpec extends Specification {
 
     def "Real MSC Ecosystem has value 1"() {
         when: "we create real ecosystem"
-        Ecosystem ecosystem = new Ecosystem(1)
+        Ecosystem ecosystem = Ecosystem.MSC
 
         then: "the value is 1"
         ecosystem == Ecosystem.MSC
-        ecosystem.shortValue() == Ecosystem.MSC_VALUE
-        ecosystem.byteValue() == (byte) 1
-        ecosystem.shortValue() == (short) 1
-        ecosystem.intValue() == 1
-        ecosystem.longValue() == 1L
+        ecosystem.getValue() == Ecosystem.MSC_VALUE
+        ecosystem.getValue() == (short) 1
     }
 
     def "Test MSC Ecosystem has value 2"() {
         when: "we create test ecosystem"
-        Ecosystem ecosystem = new Ecosystem(2)
+        Ecosystem ecosystem = Ecosystem.TMSC
 
         then: "the value is 2"
         ecosystem == Ecosystem.TMSC
-        ecosystem.shortValue() == Ecosystem.TMSC_VALUE
-        ecosystem.byteValue() == (byte) 2
-        ecosystem.shortValue() == (short) 2
-        ecosystem.intValue() == 2
-        ecosystem.longValue() == 2L
-    }
-
-    def "constructor will take short or integer"() {
-        when: "we create real ecosystem"
-        Ecosystem e1 = new Ecosystem((short) 1)
-        Ecosystem e2 = new Ecosystem(1)
-
-        then: "they are the same"
-        e1 == e2
+        ecosystem.getValue() == Ecosystem.TMSC_VALUE
+        ecosystem.getValue() == (short) 2
     }
 
     @Unroll
@@ -55,27 +40,15 @@ class EcosystemSpec extends Specification {
         id << [1F, 1.1F, 1.0D, 1.1D, 1.0, 1.1, 1.0G, 1.1G]
     }
 
-    def "We can't create an Ecosystem with an invalid value"() {
-        when: "we try to create an invalid ecosystem"
-        Ecosystem ecosystem = new Ecosystem(id)
-
-        then: "exception is thrown"
-        NumberFormatException e = thrown()
-
-        where:
-        id << [0, -1, 3]
-    }
-
     @Unroll
     def "An Ecosystem can be represented as String (#id -> #ecosystemAsString)"() {
         expect:
-        Ecosystem ecosystem = new Ecosystem(id)
         ecosystem.toString() == ecosystemAsString
 
         where:
-        id | ecosystemAsString
-        1  | "Ecosystem:1"
-        2  | "Ecosystem:2"
+        ecosystem         | ecosystemAsString
+        Ecosystem.MSC     | "Ecosystem:1"
+        Ecosystem.TMSC    | "Ecosystem:2"
     }
 
 }

--- a/omnij-core/src/test/groovy/foundation/omni/OmniAmountSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/OmniAmountSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
 class OmniAmountSpec extends Specification {
     def "can create with value and currency id"() {
         given:
-        OmniValue value = new OmniDivisibleValue(1.0)
+        OmniValue value = OmniDivisibleValue.of(1.0)
 
         when: "we create an OmniAmount"
         OmniAmount amount = new OmniAmount(value, CurrencyID.MSC)

--- a/omnij-core/src/test/groovy/foundation/omni/OmniDivisibleValueSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/OmniDivisibleValueSpec.groovy
@@ -12,7 +12,7 @@ class OmniDivisibleValueSpec extends Specification {
     @Unroll
     def "When created from willets, resulting value is scaled correctly #willets -> #expectedValue" (Long willets, BigDecimal expectedValue) {
         when: "we try to create an OmniValue using a valid numeric type"
-        OmniValue value = OmniDivisibleValue.fromWillets(willets)
+        OmniValue value = OmniDivisibleValue.ofWillets(willets)
 
         then: "it is created correctly"
         value.bigDecimalValue() == expectedValue
@@ -30,7 +30,7 @@ class OmniDivisibleValueSpec extends Specification {
     @Unroll
     def "constructor will allow a variety of integer types: #val (#type)" (Object val, Class type) {
         when: "we try to create an OmniValue using a valid numeric type"
-        OmniValue value = new OmniDivisibleValue(val)
+        OmniValue value = OmniDivisibleValue.of(val)
 
         then: "it is created correctly"
         value.longValue() == 1
@@ -42,7 +42,7 @@ class OmniDivisibleValueSpec extends Specification {
 
     def "constructor will allow a variety of integer numeric types (with class check)"() {
         when: "we try to create a OmniValue using a valid numeric type"
-        OmniValue value = new OmniDivisibleValue(val)
+        OmniValue value = OmniDivisibleValue.of(val)
 
         then: "it is created correctly"
         value.longValue() == longValue
@@ -64,10 +64,10 @@ class OmniDivisibleValueSpec extends Specification {
 
     def "constructor will allow a variety of decimal numeric types (with class check)"() {
         when: "we try to create a OmniValue using a valid numeric type"
-        OmniValue value = new OmniDivisibleValue(val)
+        OmniValue value = OmniDivisibleValue.of(val)
 
         then: "it is created correctly"
-        value.bigDecimalValue() == decimalValue
+        value.bigDecimalValue().toBigInteger() == decimalValue
 
         and: "class was as expected"
         val.class == valClass
@@ -87,7 +87,7 @@ class OmniDivisibleValueSpec extends Specification {
 
     def "constructor works with a range of values"() {
         when: "we try to create a OmniValue using a valid numeric type"
-        OmniDivisibleValue value = new OmniDivisibleValue(val)
+        OmniDivisibleValue value = OmniDivisibleValue.of(val)
 
         then: "it is created correctly"
         value.bigDecimalValue() == val
@@ -102,7 +102,7 @@ class OmniDivisibleValueSpec extends Specification {
     @Unroll
     def "constructor invalid value: #val throws #exception"() {
         when: "we try to create a OmniValue using a value that is out of range"
-        OmniDivisibleValue value = new OmniDivisibleValue(val)
+        OmniDivisibleValue value = OmniDivisibleValue.of(val)
 
         then: "Exception is thrown"
         Exception e = thrown()
@@ -110,9 +110,9 @@ class OmniDivisibleValueSpec extends Specification {
 
         where:
         val                             | exception
-        -1                              | NumberFormatException.class
+        -1                              | ArithmeticException.class
         -0.000000001                    | ArithmeticException.class
-        -0.00000001                     | NumberFormatException.class
+        -0.00000001                     | ArithmeticException.class
         0.00000000999                   | ArithmeticException.class
         0.000000009999999999999999999   | ArithmeticException.class
         0.000000001                     | ArithmeticException.class
@@ -120,15 +120,15 @@ class OmniDivisibleValueSpec extends Specification {
         1.000000009999999999999999999   | ArithmeticException.class
         1.000000001                     | ArithmeticException.class
         92233720368.54775808            | ArithmeticException.class
-        92233720369                     | NumberFormatException.class
+        92233720369                     | ArithmeticException.class
     }
 
     def "We can't create an OmniValue with an invalid value"() {
         when: "we try to create a OmniValue with an invalid value"
-        OmniValue value = new OmniDivisibleValue(val)
+        OmniValue value = OmniDivisibleValue.of(val)
 
         then: "exception is thrown"
-        NumberFormatException e = thrown()
+        ArithmeticException e = thrown()
 
         where:
         val << [-1, 9223372036854775808L]
@@ -154,20 +154,20 @@ class OmniDivisibleValueSpec extends Specification {
 
     def "Exception is thrown when converting to int would throw exception"() {
         when:
-        OmniValue value = new OmniDivisibleValue(OmniValue.MAX_VALUE)
+        OmniValue value = OmniDivisibleValue.of(OmniValue.MAX_VALUE)
         def v = value.intValue()
 
         then:
-        NumberFormatException e = thrown()
+        ArithmeticException e = thrown()
     }
 
     def "Exception is thrown when converting to int (via Groovy 'as') would throw exception"() {
         when:
-        OmniValue value = new OmniDivisibleValue(OmniValue.MAX_VALUE)
+        OmniValue value = OmniDivisibleValue.of(OmniValue.MAX_VALUE)
         def v = value as Integer
 
         then:
-        NumberFormatException e = thrown()
+        ArithmeticException e = thrown()
     }
 
 }

--- a/omnij-core/src/test/groovy/foundation/omni/OmniIndivisibleValueSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/OmniIndivisibleValueSpec.groovy
@@ -12,7 +12,7 @@ class OmniIndivisibleValueSpec extends Specification {
     @Unroll
     def "When created from willets, resulting value is unchanged #willets == #expectedValue" (Long willets, Long expectedValue) {
         when: "we try to create an OmniValue using a valid numeric type"
-        OmniValue value = OmniIndivisibleValue.fromWillets(willets)
+        OmniValue value = OmniIndivisibleValue.ofWillets(willets)
 
         then: "it is created correctly"
         value.longValue() == expectedValue
@@ -30,7 +30,7 @@ class OmniIndivisibleValueSpec extends Specification {
     @Unroll
     def "constructor will allow a variety of integer types: #val (#type)" (Object val, Class type) {
         when: "we try to create an OmniValue using a valid numeric type"
-        OmniValue value = new OmniIndivisibleValue(val)
+        OmniValue value = OmniIndivisibleValue.of(val)
 
         then: "it is created correctly"
         value.longValue() == 1
@@ -42,7 +42,7 @@ class OmniIndivisibleValueSpec extends Specification {
 
     def "constructor will allow a variety of integer types (with class check)"() {
         when: "we try to create a OmniValue using a valid numeric type"
-        OmniValue value = new OmniIndivisibleValue(val)
+        OmniValue value = OmniIndivisibleValue.of(val)
 
         then: "it is created correctly"
         value.longValue() == longValue
@@ -59,15 +59,14 @@ class OmniIndivisibleValueSpec extends Specification {
         2147483647 | 2147483647L | Integer.class
         2147483648 | 2147483648L | Long.class
         4294967295 | 4294967295L | Long.class
-        1G         | 1L          | BigInteger.class
     }
 
     def "constructor is strongly typed and won't allow all Number subclasses"() {
         when: "we try to create a OmniValue using an invalid numeric type"
-        OmniValue value = new OmniIndivisibleValue(val)
+        OmniValue value = OmniIndivisibleValue.of(val)
 
         then: "exception is thrown"
-        groovy.lang.GroovyRuntimeException e = thrown()
+        GroovyRuntimeException e = thrown()
 
         where:
         val << [1F, 1.1F, 1.0D, 1.1D, 1.0, 1.1, 1.0G, 1.1G]
@@ -75,7 +74,7 @@ class OmniIndivisibleValueSpec extends Specification {
 
     def "constructor is strongly typed and won't allow all Number subclasses (with class check)"() {
         when: "we try to create a OmniValue using an invalid numeric type"
-        OmniValue value = new OmniIndivisibleValue(val)
+        OmniValue value = OmniIndivisibleValue.of(val)
 
         then: "exception is thrown"
         GroovyRuntimeException e = thrown()
@@ -97,10 +96,10 @@ class OmniIndivisibleValueSpec extends Specification {
 
     def "We can't create an OmniValue with an invalid value"() {
         when: "we try to create a OmniValue with an invalid value"
-        OmniValue value = new OmniIndivisibleValue(val)
+        OmniValue value = OmniIndivisibleValue.of(val)
 
         then: "exception is thrown"
-        NumberFormatException e = thrown()
+        ArithmeticException e = thrown()
 
         where:
         val << [-1, 9223372036854775808L]
@@ -126,7 +125,7 @@ class OmniIndivisibleValueSpec extends Specification {
 
     def "Exception is thrown when converting to int would throw exception"() {
         when:
-        OmniValue value = new OmniIndivisibleValue(OmniValue.MAX_VALUE)
+        OmniValue value = OmniIndivisibleValue.of(OmniValue.MAX_VALUE)
         def v = value.intValue()
 
         then:
@@ -135,7 +134,7 @@ class OmniIndivisibleValueSpec extends Specification {
 
     def "Exception is thrown when converting to int (via Groovy 'as') would throw exception"() {
         when:
-        OmniValue value = new OmniIndivisibleValue(OmniValue.MAX_VALUE)
+        OmniValue value = OmniIndivisibleValue.of(OmniValue.MAX_VALUE)
         def v = value as Integer
 
         then:

--- a/omnij-core/src/test/groovy/foundation/omni/OmniValueSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/OmniValueSpec.groovy
@@ -26,8 +26,8 @@ class OmniValueSpec extends Specification {
         when: "we check the value"
         OmniValue.checkValue(val)
 
-        then: "NumberFormatException is thrown"
-        NumberFormatException e = thrown()
+        then: "ArithmeticException is thrown"
+        ArithmeticException e = thrown()
 
         where:
         val << [-1, -2, -9223372036854775807L, -9223372036854775808L]
@@ -50,8 +50,8 @@ class OmniValueSpec extends Specification {
         when: "we check the value"
         OmniValue.checkValue(val)
 
-        then: "NumberFormatException is thrown"
-        NumberFormatException e = thrown()
+        then: "ArithmeticException is thrown"
+        ArithmeticException e = thrown()
 
         where:
         val << [-99999999999999999999999999G, -9223372036854775808G, -9223372036854775807G, -2, -1,

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ConsensusSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ConsensusSpec.groovy
@@ -17,7 +17,7 @@ class ConsensusSpec extends BaseRegTestSpec {
 
     def "Check all balances, raw CLI, type Long"() {
         when: "we check Omni balances"
-        def balances = cliSend("getallbalancesforid_MP", MSC.longValue())
+        def balances = cliSend("getallbalancesforid_MP", MSC.getValue())
 
         then: "we get a list of size >= 0"
         balances != null

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/dex/DexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/dex/DexSpec.groovy
@@ -57,7 +57,7 @@ class DexSpec extends BaseRegTestSpec {
         then: "the transaction should be a valid offering of #currencyOffered"
         def offerTx = getTransactionMP(offerTxid)
         offerTx.valid == true
-        offerTx.propertyid == currencyOffered.longValue()
+        offerTx.propertyid == currencyOffered.getValue()
 
         where: "the currency identifier is either MSC or TMSC"
         currencyOffered << [CurrencyID.MSC, CurrencyID.TMSC]

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
@@ -221,8 +221,8 @@ class MetaDexSpec extends BaseRegTestSpec {
         then: "it is a valid open order"
         gettrade_MP(txidOfferA).valid
         gettrade_MP(txidOfferA).status == "open"
-        gettrade_MP(txidOfferA).propertyidforsale == propertyMSC.longValue()
-        gettrade_MP(txidOfferA).propertyiddesired == propertySPX.longValue()
+        gettrade_MP(txidOfferA).propertyidforsale == propertyMSC.getValue()
+        gettrade_MP(txidOfferA).propertyiddesired == propertySPX.getValue()
 
         and: "there is an offering for the new property in the orderbook"
         getorderbook_MP(propertyMSC, propertySPX).size() == 1
@@ -238,8 +238,8 @@ class MetaDexSpec extends BaseRegTestSpec {
         then: "the order is filled"
         gettrade_MP(txidOfferB).valid
         gettrade_MP(txidOfferB).status == "filled"
-        gettrade_MP(txidOfferB).propertyidforsale == propertySPX.longValue()
-        gettrade_MP(txidOfferB).propertyiddesired == propertyMSC.longValue()
+        gettrade_MP(txidOfferB).propertyidforsale == propertySPX.getValue()
+        gettrade_MP(txidOfferB).propertyiddesired == propertyMSC.getValue()
 
         and: "the offering is no longer listed in the orderbook"
         getorderbook_MP(propertyMSC, propertySPX).size() == 0
@@ -295,8 +295,8 @@ class MetaDexSpec extends BaseRegTestSpec {
         then: "it is a valid open order"
         gettrade_MP(txidOfferA).valid
         gettrade_MP(txidOfferA).status == "open"
-        gettrade_MP(txidOfferA).propertyidforsale == propertySPX.longValue()
-        gettrade_MP(txidOfferA).propertyiddesired == propertyMSC.longValue()
+        gettrade_MP(txidOfferA).propertyidforsale == propertySPX.getValue()
+        gettrade_MP(txidOfferA).propertyiddesired == propertyMSC.getValue()
 
         and: "there is an offering for the new property in the orderbook"
         getorderbook_MP(propertySPX, propertyMSC).size() == 1
@@ -312,8 +312,8 @@ class MetaDexSpec extends BaseRegTestSpec {
         then: "the order is filled"
         gettrade_MP(txidOfferB).valid
         gettrade_MP(txidOfferB).status == "filled"
-        gettrade_MP(txidOfferB).propertyidforsale == propertyMSC.longValue()
-        gettrade_MP(txidOfferB).propertyiddesired == propertySPX.longValue()
+        gettrade_MP(txidOfferB).propertyidforsale == propertyMSC.getValue()
+        gettrade_MP(txidOfferB).propertyiddesired == propertySPX.getValue()
 
         and: "the offering is no longer listed in the orderbook"
         getorderbook_MP(propertySPX, propertyMSC).size() == 0

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
@@ -29,13 +29,13 @@ class PropertyCreationReorgSpec extends BaseReorgSpec {
         if (lastMainPropertyID == CurrencyID.MSC) {
             nextMainPropertyID = new CurrencyID(CurrencyID.TMSC_VALUE + 1)
         } else {
-            nextMainPropertyID = new CurrencyID(lastMainPropertyID.longValue() + 1)
+            nextMainPropertyID = new CurrencyID(lastMainPropertyID.getValue() + 1)
         }
 
         if (lastTestPropertyID == CurrencyID.TMSC) {
             nextTestPropertyID = new CurrencyID(2147483651L)
         } else {
-            nextTestPropertyID = new CurrencyID(lastTestPropertyID.longValue() + 1)
+            nextTestPropertyID = new CurrencyID(lastTestPropertyID.getValue() + 1)
         }
     }
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendall/SendAllSpec.groovy
@@ -44,7 +44,7 @@ class SendAllSpec extends BaseRegTestSpec {
         and:
         List<Map<String, Object>> subSends = sendTx['subsends']
         subSends.size() == 1
-        subSends[0].propertyid == ecosystem.longValue()
+        subSends[0].propertyid == ecosystem.getValue()
         subSends[0].divisible
         subSends[0].amount as BigDecimal == startMSC
 
@@ -103,7 +103,7 @@ class SendAllSpec extends BaseRegTestSpec {
         def actorAddress = createFundedAddress(startBTC, zeroAmount)
         def otherAddress = createFundedAddress(startBTC, zeroAmount)
         def nonManagedID = fundNewProperty(actorAddress, 10.0, PropertyType.DIVISIBLE, ecosystem)
-        def tradeCurrency = new CurrencyID(ecosystem.longValue())
+        def tradeCurrency = new CurrencyID(ecosystem.getValue())
 
         then:
         getbalance_MP(actorAddress, nonManagedID).balance == 10.0

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
@@ -56,7 +56,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         def propertyInfo = getproperty_MP(currencyID)
 
         then:
-        propertyInfo.propertyid == currencyID.longValue()
+        propertyInfo.propertyid == currencyID.getValue()
         propertyInfo.divisible == false
         propertyInfo.name == "ManagedTokens"
         propertyInfo.category == "Test Category"
@@ -101,7 +101,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getTransactionMP(txid).txid == txid.toString()
         getTransactionMP(txid).valid
         getTransactionMP(txid).type_int == 55
-        getTransactionMP(txid).propertyid == currencyID.longValue()
+        getTransactionMP(txid).propertyid == currencyID.getValue()
         getTransactionMP(txid).divisible == false
         getTransactionMP(txid).amount as Integer == 100
     }
@@ -132,7 +132,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getTransactionMP(txid).txid == txid.toString()
         getTransactionMP(txid).valid
         getTransactionMP(txid).type_int == 55
-        getTransactionMP(txid).propertyid == currencyID.longValue()
+        getTransactionMP(txid).propertyid == currencyID.getValue()
         getTransactionMP(txid).divisible == false
         getTransactionMP(txid).amount as Integer == 170
 
@@ -241,7 +241,7 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         getTransactionMP(txid).txid == txid.toString()
         getTransactionMP(txid).valid
         getTransactionMP(txid).type_int == 56
-        getTransactionMP(txid).propertyid == currencyID.longValue()
+        getTransactionMP(txid).propertyid == currencyID.getValue()
         getTransactionMP(txid).divisible == false
         getTransactionMP(txid).amount as Long == new Long("9223372036854775805")
     }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
@@ -43,7 +43,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         given:
         def startMSC = mscAvailable + mscReserved
         def actorAddress = createFundedAddress(startBTC, startMSC, false)
-        def currencyMSC = new CurrencyID(ecosystem.longValue())
+        def currencyMSC = new CurrencyID(ecosystem.getValue())
         def currencySPT = getStoProperty(actorAddress, data)
 
         // Create a DEx offer to reserve an amount
@@ -121,7 +121,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def expectedValidity = false
 
         def actorAddress = createFundedAddress(startBTC, startMSC)
-        def currencyMSC = new CurrencyID(ecosystem.longValue())
+        def currencyMSC = new CurrencyID(ecosystem.getValue())
         def currencySPT = new CurrencyID(4294967295L) // does not exist
 
         given: "the actor starts with #startMSC #currencyMSC"
@@ -151,7 +151,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def startMSC = 2.0
         def expectException = true
         def expectedValidity = false
-        def currencyMSC = new CurrencyID(ecosystem.longValue())
+        def currencyMSC = new CurrencyID(ecosystem.getValue())
 
         when: "there is a well funded actor and two owners with bitcoin"
         def actorAddress = createFundedAddress(btcAvailable, startMSC)
@@ -191,7 +191,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def startMSC = 1.0
         def expectException = false
         def expectedValidity = false
-        def currencyMSC = new CurrencyID(ecosystem.longValue())
+        def currencyMSC = new CurrencyID(ecosystem.getValue())
 
         def actorAddress = createFundedAddress(startBTC, startMSC)
         def ownerA = createFundedAddress(startBTC, startMSC)
@@ -261,7 +261,7 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def reservedOwnerC = 0.0
         def expectException = false
         def expectedValidity = true
-        def currencyMSC = new CurrencyID(ecosystem.longValue())
+        def currencyMSC = new CurrencyID(ecosystem.getValue())
 
         def numberOfAllOwners = getproperty_MP(currencyMSC).size()
         if (BTC.btcToSatoshis(startMSC - amountSTO) < (numberOfAllOwners - 1)) {

--- a/omnij-rpc/src/main/groovy/foundation/omni/consensus/ChestConsensusTool.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/consensus/ChestConsensusTool.groovy
@@ -37,7 +37,7 @@ class ChestConsensusTool extends ConsensusTool {
 
     private SortedMap<Address, ConsensusEntry> getConsensusForCurrency(CurrencyID currencyID) {
         def slurper = new JsonSlurper()
-        String httpFile = "${file}?currencyid=${currencyID.longValue()}"
+        String httpFile = "${file}?currencyid=${currencyID.getValue()}"
         def consensusURL = new URL(proto, host, port, httpFile)
 //        def balancesText =  consensusURL.getText()
         def balances = slurper.parse(consensusURL)
@@ -112,7 +112,7 @@ class ChestConsensusTool extends ConsensusTool {
 
     @Override
     public ConsensusSnapshot getConsensusSnapshot(CurrencyID currencyID) {
-        String httpFile = "${file}?currencyid=${currencyID.longValue()}"
+        String httpFile = "${file}?currencyid=${currencyID.getValue()}"
         def consensusURL = new URL(proto, host, port, httpFile)
 
         /* Since getConsensusForCurrency can't return the blockHeight, we have to check

--- a/omnij-rpc/src/main/groovy/foundation/omni/consensus/OmniwalletConsensusTool.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/consensus/OmniwalletConsensusTool.groovy
@@ -115,7 +115,7 @@ class OmniwalletConsensusTool extends ConsensusTool {
 
     @Override
     public ConsensusSnapshot getConsensusSnapshot(CurrencyID currencyID) {
-        String httpFile = "${file}?currency_id=${currencyID.longValue()}"
+        String httpFile = "${file}?currency_id=${currencyID.getValue()}"
         def consensusURL = new URL(proto, host, port, httpFile)
 
         /* Since getConsensusForCurrency() doesn't return the blockHeight, we have to check

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -3,6 +3,9 @@ package foundation.omni.test
 import com.msgilligan.bitcoin.BTC
 import com.msgilligan.bitcoin.test.BTCTestSupport
 import foundation.omni.Ecosystem
+import foundation.omni.OmniDivisibleValue
+import foundation.omni.OmniIndivisibleValue
+import foundation.omni.OmniValue
 import foundation.omni.PropertyType
 import foundation.omni.rpc.RawTxDelegate
 import org.bitcoinj.core.Address
@@ -89,11 +92,9 @@ trait OmniTestSupport implements BTCTestSupport, OmniClientDelegate, RawTxDelega
         return fundedAddress
     }
 
-    CurrencyID fundNewProperty(Address address, BigDecimal amount, PropertyType type, Ecosystem ecosystem) {
-        if (type == PropertyType.DIVISIBLE) {
-            amount = BTC.btcToSatoshis(amount)
-        }
-        def txidCreation = createProperty(address, ecosystem, type, amount.longValue())
+    CurrencyID fundNewProperty(Address address, BigDecimal amountBD, PropertyType type, Ecosystem ecosystem) {
+        OmniValue amount = OmniValue.of(amountBD, type);
+        def txidCreation = createProperty(address, ecosystem, type, amount.asWillets())
         generateBlock()
         def txCreation = getTransactionMP(txidCreation)
         assert txCreation.valid == true

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -90,7 +90,7 @@ public class OmniClient extends BitcoinClient {
      * @return An object with detailed information
      */
     public Map<String, Object> getproperty_MP(CurrencyID currency) throws JsonRPCException, IOException {
-        List<Object> params = createParamList(currency.longValue());
+        List<Object> params = createParamList(currency.getValue());
         Map<String, Object> result = send("getproperty_MP", params);
         return result;
     }
@@ -102,7 +102,7 @@ public class OmniClient extends BitcoinClient {
      * @return An object with detailed information
      */
     public Map<String, Object> getcrowdsale_MP(CurrencyID currency) throws JsonRPCException, IOException {
-        List<Object> params = createParamList(currency.longValue());
+        List<Object> params = createParamList(currency.getValue());
         Map<String, Object> result = send("getcrowdsale_MP", params);
         return result;
     }
@@ -126,7 +126,7 @@ public class OmniClient extends BitcoinClient {
      */
     public MPBalanceEntry getbalance_MP(Address address, CurrencyID currency)
             throws JsonRPCException, IOException, ParseException {
-        List<Object> params = createParamList(address.toString(), currency.longValue());
+        List<Object> params = createParamList(address.toString(), currency.getValue());
         Map<String, String> result = send("getbalance_MP", params);
         BigDecimal balanceBTC = (BigDecimal) jsonDecimalFormat.parse(result.get("balance"));
         BigDecimal reservedBTC = (BigDecimal) jsonDecimalFormat.parse(result.get("reserved"));
@@ -142,7 +142,7 @@ public class OmniClient extends BitcoinClient {
      */
     public List<MPBalanceEntry> getallbalancesforid_MP(CurrencyID currency)
             throws JsonRPCException, IOException, ParseException, AddressFormatException {
-        List<Object> params = createParamList(currency.longValue());
+        List<Object> params = createParamList(currency.getValue());
         List<Map<String, Object>> untypedBalances = send("getallbalancesforid_MP", params);
         List<MPBalanceEntry> balances = new ArrayList<MPBalanceEntry>(untypedBalances.size());
         for (Map map : untypedBalances) {
@@ -223,7 +223,7 @@ public class OmniClient extends BitcoinClient {
      */
     public Sha256Hash send_MP(Address fromAddress, Address toAddress, CurrencyID currency, BigDecimal amount)
             throws JsonRPCException, IOException {
-        List<Object> params = createParamList(fromAddress.toString(), toAddress.toString(), currency.longValue(),
+        List<Object> params = createParamList(fromAddress.toString(), toAddress.toString(), currency.getValue(),
                                               amount.toPlainString());
         String txid = send("send_MP", params);
         Sha256Hash hash = Sha256Hash.wrap(txid);
@@ -240,7 +240,7 @@ public class OmniClient extends BitcoinClient {
      */
     public Sha256Hash sendToOwnersMP(Address fromAddress, CurrencyID currency, BigDecimal amount)
             throws JsonRPCException, IOException {
-        List<Object> params = createParamList(fromAddress.toString(), currency.longValue(), amount.toPlainString());
+        List<Object> params = createParamList(fromAddress.toString(), currency.getValue(), amount.toPlainString());
         String txid = send("sendtoowners_MP", params);
         Sha256Hash hash = Sha256Hash.wrap(txid);
         return hash;
@@ -256,7 +256,7 @@ public class OmniClient extends BitcoinClient {
      */
     public Sha256Hash sendAll(Address fromAddress, Address toAddress, Ecosystem ecosystem)
             throws JsonRPCException, IOException {
-        List<Object> params = createParamList(fromAddress.toString(), toAddress.toString(), ecosystem.byteValue());
+        List<Object> params = createParamList(fromAddress.toString(), toAddress.toString(), ecosystem.getValue());
         String txid = send("omni_sendall", params);
         Sha256Hash hash = Sha256Hash.wrap(txid);
         return hash;
@@ -277,8 +277,8 @@ public class OmniClient extends BitcoinClient {
     public Sha256Hash trade_MP(Address fromAddress, CurrencyID propertyForSale, BigDecimal amountForSale,
                                CurrencyID propertyDesired, BigDecimal amountDesired, Byte action)
             throws JsonRPCException, IOException {
-        List<Object> params = createParamList(fromAddress.toString(), propertyForSale.longValue(),
-                                              amountForSale.toPlainString(), propertyDesired.longValue(),
+        List<Object> params = createParamList(fromAddress.toString(), propertyForSale.getValue(),
+                                              amountForSale.toPlainString(), propertyDesired.getValue(),
                                               amountDesired.toPlainString(), action);
         String txid = send("trade_MP", params);
         Sha256Hash hash = Sha256Hash.wrap(txid);
@@ -306,7 +306,7 @@ public class OmniClient extends BitcoinClient {
      * @since Omni Core 0.0.10
      */
     public List<Map<String, Object>> getorderbook_MP(CurrencyID propertyForSale) throws JsonRPCException, IOException {
-        List<Object> params = createParamList(propertyForSale.longValue());
+        List<Object> params = createParamList(propertyForSale.getValue());
         List<Map<String, Object>> orders = send("getorderbook_MP", params);
         return orders;
     }
@@ -321,7 +321,7 @@ public class OmniClient extends BitcoinClient {
      */
     public List<Map<String, Object>> getorderbook_MP(CurrencyID propertyForSale, CurrencyID propertyDesired)
             throws JsonRPCException, IOException {
-        List<Object> params = createParamList(propertyForSale.longValue(), propertyDesired.longValue());
+        List<Object> params = createParamList(propertyForSale.getValue(), propertyDesired.getValue());
         List<Map<String, Object>> orders = send("getorderbook_MP", params);
         return orders;
     }

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
@@ -5,6 +5,7 @@ import com.msgilligan.bitcoin.rpc.JsonRPCException;
 import com.msgilligan.bitcoin.rpc.RPCConfig;
 import foundation.omni.CurrencyID;
 import foundation.omni.Ecosystem;
+import foundation.omni.OmniDivisibleValue;
 import foundation.omni.PropertyType;
 import foundation.omni.tx.RawTxBuilder;
 import org.bitcoinj.core.Address;
@@ -61,11 +62,11 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash createDexSellOffer(Address address, CurrencyID currencyId, BigDecimal amountForSale,
                                   BigDecimal amountDesired, Byte paymentWindow, BigDecimal commitmentFee,
                                   Byte action) throws JsonRPCException, IOException {
-        Coin satoshisForSale = BTC.btcToCoin(amountForSale);
+        OmniDivisibleValue quantityForSale = OmniDivisibleValue.of(amountForSale);
         Coin satoshisDesired = BTC.btcToCoin(amountDesired);
         Coin satoshisFee = BTC.btcToCoin(commitmentFee);
         String rawTxHex = builder.createDexSellOfferHex(
-                currencyId, satoshisForSale.value, satoshisDesired.value, paymentWindow, satoshisFee.value, action);
+                currencyId, quantityForSale.asWillets(), satoshisDesired.value, paymentWindow, satoshisFee.value, action);
         Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
         return txid;
     }
@@ -81,8 +82,8 @@ public class OmniExtendedClient extends OmniClient {
      */
     public Sha256Hash acceptDexOffer(Address fromAddress, CurrencyID currencyId, BigDecimal amount, Address toAddress)
             throws JsonRPCException, IOException {
-        Coin satoshis = BTC.btcToCoin(amount);
-        String rawTxHex = builder.createAcceptDexOfferHex(currencyId, satoshis.value);
+        OmniDivisibleValue quantity = OmniDivisibleValue.of(amount);
+        String rawTxHex = builder.createAcceptDexOfferHex(currencyId, quantity.asWillets());
         Sha256Hash txid = sendrawtx_MP(fromAddress, rawTxHex, toAddress);
         return txid;
     }
@@ -104,10 +105,10 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash createMetaDexSellOffer(Address address, CurrencyID currencyForSale, BigDecimal amountForSale,
                                       CurrencyID currencyDesired, BigDecimal amountDesired,
                                       Byte action) throws JsonRPCException, IOException {
-        Coin willetsForSale = BTC.btcToCoin(amountForSale);  // Assume divisible property
-        Coin willetsDesired = BTC.btcToCoin(amountDesired);  // Assume divisible property
+        OmniDivisibleValue qtyForSale = OmniDivisibleValue.of(amountForSale);  // Assume divisible property
+        OmniDivisibleValue qtyDesired = OmniDivisibleValue.of(amountDesired);  // Assume divisible property
         String rawTxHex = builder.createMetaDexSellOfferHex(
-                currencyForSale, willetsForSale.value, currencyDesired, willetsDesired.value, action);
+                currencyForSale, qtyForSale.asWillets(), currencyDesired, qtyDesired.asWillets(), action);
         Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
         return txid;
     }

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniExtendedClient.java
@@ -8,6 +8,7 @@ import foundation.omni.Ecosystem;
 import foundation.omni.PropertyType;
 import foundation.omni.tx.RawTxBuilder;
 import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Sha256Hash;
 
 import java.io.IOException;
@@ -60,11 +61,11 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash createDexSellOffer(Address address, CurrencyID currencyId, BigDecimal amountForSale,
                                   BigDecimal amountDesired, Byte paymentWindow, BigDecimal commitmentFee,
                                   Byte action) throws JsonRPCException, IOException {
-        Long satoshisForSale = BTC.btcToSatoshis(amountForSale).longValue();
-        Long satoshisDesired = BTC.btcToSatoshis(amountDesired).longValue();
-        Long satoshisFee = BTC.btcToSatoshis(commitmentFee).longValue();
+        Coin satoshisForSale = BTC.btcToCoin(amountForSale);
+        Coin satoshisDesired = BTC.btcToCoin(amountDesired);
+        Coin satoshisFee = BTC.btcToCoin(commitmentFee);
         String rawTxHex = builder.createDexSellOfferHex(
-                currencyId, satoshisForSale, satoshisDesired, paymentWindow, satoshisFee, action);
+                currencyId, satoshisForSale.value, satoshisDesired.value, paymentWindow, satoshisFee.value, action);
         Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
         return txid;
     }
@@ -80,8 +81,8 @@ public class OmniExtendedClient extends OmniClient {
      */
     public Sha256Hash acceptDexOffer(Address fromAddress, CurrencyID currencyId, BigDecimal amount, Address toAddress)
             throws JsonRPCException, IOException {
-        Long satoshis = BTC.btcToSatoshis(amount).longValue();
-        String rawTxHex = builder.createAcceptDexOfferHex(currencyId, satoshis);
+        Coin satoshis = BTC.btcToCoin(amount);
+        String rawTxHex = builder.createAcceptDexOfferHex(currencyId, satoshis.value);
         Sha256Hash txid = sendrawtx_MP(fromAddress, rawTxHex, toAddress);
         return txid;
     }
@@ -103,10 +104,10 @@ public class OmniExtendedClient extends OmniClient {
     public Sha256Hash createMetaDexSellOffer(Address address, CurrencyID currencyForSale, BigDecimal amountForSale,
                                       CurrencyID currencyDesired, BigDecimal amountDesired,
                                       Byte action) throws JsonRPCException, IOException {
-        Long willetsForSale = BTC.btcToSatoshis(amountForSale).longValue();  // Assume divisible property
-        Long willetsDesired = BTC.btcToSatoshis(amountDesired).longValue();  // Assume divisible property
+        Coin willetsForSale = BTC.btcToCoin(amountForSale);  // Assume divisible property
+        Coin willetsDesired = BTC.btcToCoin(amountDesired);  // Assume divisible property
         String rawTxHex = builder.createMetaDexSellOfferHex(
-                currencyForSale, willetsForSale, currencyDesired, willetsDesired, action);
+                currencyForSale, willetsForSale.value, currencyDesired, willetsDesired.value, action);
         Sha256Hash txid = sendrawtx_MP(address, rawTxHex);
         return txid;
     }


### PR DESCRIPTION
* Simplify and move away from BTC utility class where possible
* Make better use of bitcoinj Coin class where possible
* Ecosystem and PropertyType no longer extend Number
* Use getValue() rather than byteValue(), shortValue(), etc
* Make some constructors private, e.g. Ecosystem, PropertyType
* Use .of() method for creating Omni*Value types
* .asWillets() method for extracting willet internal/wire representation
* Consistently use ArithmeticException (not NumberFormatException)
* Add important design note JavaDoc to OmniValue class