### PR TITLE
Add tests and helpers related to feature activations

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
@@ -1,0 +1,37 @@
+package foundation.omni.test.rpc.activation
+
+import foundation.omni.BaseRegTestSpec
+import org.junit.internal.AssumptionViolatedException
+
+/**
+ * Base specification for feature activations in regtest mode
+ *
+ * The use of activation commands is restricted to whitelisted senders. To whitelist a source to allow feature
+ * activations, the option {@code -omniactivationallowsender="sender"} can be used.
+ */
+abstract class BaseActivationSpec extends BaseRegTestSpec {
+
+    // Activation grace period
+    static final protected Integer activationMinBlocks = 5
+    static final protected Integer activationMaxBlocks = 10
+
+    // Feature identifiers
+    static final protected Short metaDExFeatureId = 2
+    static final protected Short unallocatedFeatureId = 3
+    static final protected Short overOffersFeatureId = 5
+
+    // Default values
+    static protected Integer minClientVersion = 0
+    static protected BigDecimal startBTC = 0.1
+    static protected BigDecimal startMSC = 0.1
+    static protected BigDecimal zeroAmount = 0.0
+
+    def setupSpec() {
+        if (!commandExists('omni_sendactivation')) {
+            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
+        }
+        if (!commandExists('omni_getactivations')) {
+            throw new AssumptionViolatedException('The client has no "omni_getactivations" command')
+        }
+    }
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
@@ -1,5 +1,6 @@
 package foundation.omni.test.rpc.activation
 
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 /**
@@ -12,6 +13,7 @@ import spock.lang.Unroll
  *
  * Note: this test is only successful with a clean state!
  */
+@Ignore('the tests can only be executed with a pristine state')
 class GracePeriodSpec extends BaseActivationSpec {
 
     @Unroll

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
@@ -1,0 +1,85 @@
+package foundation.omni.test.rpc.activation
+
+import foundation.omni.BaseRegTestSpec
+import org.junit.internal.AssumptionViolatedException
+import spock.lang.Unroll
+
+/**
+ * Specification for the grace period of feature activations.
+ *
+ * Features are activated at specific block heights, which must be within the range of a grace period to ensure
+ * users have enough time to update their clients.
+ *
+ * The use of activation commands is restricted to whitelisted senders. To whitelist a source to allow feature
+ * activations, the option {@code -omniactivationallowsender="sender"} can be used.
+ *
+ * The feature identifier 3 is currently unused, and a good candidate for tests.
+ *
+ * Note: this test is only successful with a clean state!
+ */
+class GracePeriodSpec extends BaseRegTestSpec {
+
+    final static Integer minClientVersion = 0
+    final static Integer activationMinBlocks = 5
+    final static Integer activationMaxBlocks = 10
+    final static Short featureId = 3
+    final static BigDecimal startBTC = 0.001
+    final static BigDecimal zeroAmount = 0.0
+
+    @Unroll
+    def "A relative activation height of #blockOffset blocks is smaller than the grace period and not allowed"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, zeroAmount)
+        def activationBlock = getBlockCount() + blockOffset + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        where:
+        blockOffset << [-100, 0, 1, 2, 4]
+    }
+
+    @Unroll
+    def "A relative activation height of #blockOffset blocks is too far in the future and not allowed"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, zeroAmount)
+        def activationBlock = getBlockCount() + blockOffset + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        where:
+        blockOffset << [11, 288, 12289, 999999]
+    }
+
+    @Unroll
+    def "A relative activation height of #blockOffset blocks is within the grace period and accepted"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, zeroAmount)
+        def activationBlock = getBlockCount() + blockOffset + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == true
+
+        where:
+        blockOffset << [activationMinBlocks, activationMinBlocks + 1, activationMaxBlocks - 1, activationMaxBlocks]
+    }
+
+    def setupSpec() {
+        if (!commandExists('omni_sendactivation')) {
+            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
+        }
+    }
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
@@ -1,6 +1,5 @@
 package foundation.omni.test.rpc.activation
 
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 /**
@@ -10,10 +9,7 @@ import spock.lang.Unroll
  * users have enough time to update their clients.
  *
  * The feature identifier 3 is currently unused, and a good candidate for tests.
- *
- * Note: this test is only successful with a clean state!
  */
-@Ignore('the tests can only be executed with a pristine state')
 class GracePeriodSpec extends BaseActivationSpec {
 
     @Unroll

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
@@ -1,7 +1,5 @@
 package foundation.omni.test.rpc.activation
 
-import foundation.omni.BaseRegTestSpec
-import org.junit.internal.AssumptionViolatedException
 import spock.lang.Unroll
 
 /**
@@ -10,21 +8,11 @@ import spock.lang.Unroll
  * Features are activated at specific block heights, which must be within the range of a grace period to ensure
  * users have enough time to update their clients.
  *
- * The use of activation commands is restricted to whitelisted senders. To whitelist a source to allow feature
- * activations, the option {@code -omniactivationallowsender="sender"} can be used.
- *
  * The feature identifier 3 is currently unused, and a good candidate for tests.
  *
  * Note: this test is only successful with a clean state!
  */
-class GracePeriodSpec extends BaseRegTestSpec {
-
-    final static Integer minClientVersion = 0
-    final static Integer activationMinBlocks = 5
-    final static Integer activationMaxBlocks = 10
-    final static Short featureId = 3
-    final static BigDecimal startBTC = 0.001
-    final static BigDecimal zeroAmount = 0.0
+class GracePeriodSpec extends BaseActivationSpec {
 
     @Unroll
     def "A relative activation height of #blockOffset blocks is smaller than the grace period and not allowed"() {
@@ -33,7 +21,7 @@ class GracePeriodSpec extends BaseRegTestSpec {
         def activationBlock = getBlockCount() + blockOffset + 1 // one extra, for transaction confirmation
 
         when:
-        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        def txid = omniSendActivation(actorAddress, unallocatedFeatureId, activationBlock, minClientVersion)
         generateBlock()
 
         then:
@@ -50,7 +38,7 @@ class GracePeriodSpec extends BaseRegTestSpec {
         def activationBlock = getBlockCount() + blockOffset + 1 // one extra, for transaction confirmation
 
         when:
-        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        def txid = omniSendActivation(actorAddress, unallocatedFeatureId, activationBlock, minClientVersion)
         generateBlock()
 
         then:
@@ -67,7 +55,7 @@ class GracePeriodSpec extends BaseRegTestSpec {
         def activationBlock = getBlockCount() + blockOffset + 1 // one extra, for transaction confirmation
 
         when:
-        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        def txid = omniSendActivation(actorAddress, unallocatedFeatureId, activationBlock, minClientVersion)
         generateBlock()
 
         then:
@@ -75,11 +63,5 @@ class GracePeriodSpec extends BaseRegTestSpec {
 
         where:
         blockOffset << [activationMinBlocks, activationMinBlocks + 1, activationMaxBlocks - 1, activationMaxBlocks]
-    }
-
-    def setupSpec() {
-        if (!commandExists('omni_sendactivation')) {
-            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
-        }
     }
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
@@ -1,0 +1,225 @@
+package foundation.omni.test.rpc.activation
+
+import foundation.omni.BaseRegTestSpec
+import foundation.omni.CurrencyID
+import foundation.omni.Ecosystem
+import foundation.omni.PropertyType
+import org.bitcoinj.core.Address
+import org.junit.internal.AssumptionViolatedException
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+/**
+ * Specification for the activation of the distributed token exchange.
+ *
+ * Once the feature with identifier 2 is active, the distributed token exchange can be used with non-test tokens.
+ *
+ * During the grace period, the old rules are still in place.
+ *
+ * Note: this test is only successful with a clean state, and requires that the feature is initially disabled!
+ */
+@Stepwise
+class MetaDExActivationSpec extends BaseRegTestSpec {
+
+    final static Integer minClientVersion = 0
+    final static Integer activationMinBlocks = 5
+    final static Short featureId = 2
+    final static BigDecimal startBTC = 0.1
+    final static BigDecimal startMSC = 0.1
+
+    @Shared Integer activationBlock = 999999
+    @Shared Address actorAddress
+    @Shared CurrencyID mainID
+    @Shared CurrencyID testID
+
+    def setupSpec() {
+        if (!commandExists('omni_sendactivation')) {
+            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
+        }
+
+        actorAddress = createFundedAddress(startBTC, startMSC)
+        mainID = fundNewProperty(actorAddress, 10.0, PropertyType.DIVISIBLE, Ecosystem.MSC)
+        testID = fundNewProperty(actorAddress, 15.0, PropertyType.DIVISIBLE, Ecosystem.TMSC)
+    }
+
+    def "Creating trades involving test ecosystem tokens before the activation is valid"() {
+        setup:
+        def amountForSale = 3.0
+        def amountDesired = 5.0
+        def balanceAtStart = omniGetBalance(actorAddress, testID)
+
+        when:
+        def tradeTxid = omniSendTrade(actorAddress, testID, amountForSale, CurrencyID.TMSC, amountDesired)
+        generateBlock()
+
+        then:
+        omniGetTransaction(tradeTxid).valid
+
+        and:
+        omniGetTrade(tradeTxid).status == "open"
+        omniGetTrade(tradeTxid).amountremaining as BigDecimal == amountForSale
+        omniGetTrade(tradeTxid).amounttofill as BigDecimal == amountDesired
+        omniGetTrade(tradeTxid).amountforsale as BigDecimal == amountForSale
+        omniGetTrade(tradeTxid).amountdesired as BigDecimal == amountDesired
+        omniGetTrade(tradeTxid).propertyidforsale == testID.getValue()
+        omniGetTrade(tradeTxid).propertyiddesired == CurrencyID.TMSC.getValue()
+        omniGetTrade(tradeTxid).propertyidforsaleisdivisible
+        omniGetTrade(tradeTxid).propertyiddesiredisdivisible
+        omniGetTrade(tradeTxid).unitprice == "1.66666666666666666666666666666666666666666666666667"
+
+        and:
+        omniGetBalance(actorAddress, testID).balance == balanceAtStart.balance - amountForSale
+        omniGetBalance(actorAddress, testID).reserved == balanceAtStart.reserved + amountForSale
+
+        when:
+        def cancelTxid = omniSendCancelAllTrades(actorAddress, Ecosystem.TMSC)
+        generateBlock()
+
+        then:
+        omniGetTrade(cancelTxid).valid
+        omniGetTrade(cancelTxid).ecosystem == "test"
+
+        and:
+        omniGetTrade(tradeTxid).status == "cancelled"
+        omniGetTrade(tradeTxid).amountforsale as BigDecimal == amountForSale
+        omniGetTrade(tradeTxid).amountdesired as BigDecimal == amountDesired
+        omniGetTrade(tradeTxid).propertyidforsale == testID.getValue()
+        omniGetTrade(tradeTxid).propertyiddesired == CurrencyID.TMSC.getValue()
+
+        and:
+        omniGetBalance(actorAddress, testID) == balanceAtStart
+    }
+
+    def "Creating trades involving main ecosystem tokens before the activation is invalid"() {
+        when:
+        def txid = omniSendTrade(actorAddress, mainID, 5.0, CurrencyID.MSC, 2.0)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        and:
+        omniGetBalance(actorAddress, mainID) == old(omniGetBalance(actorAddress, mainID))
+        omniGetBalance(actorAddress, CurrencyID.MSC) == old(omniGetBalance(actorAddress, CurrencyID.MSC))
+    }
+
+    def "Feature identifier 2 can be used to schedule the activation of the distributed token exchange"() {
+        setup:
+        activationBlock = getBlockCount() + activationMinBlocks + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+
+        when:
+        def activations = omniGetActivations()
+        def pendingActivations = activations.pendingactivations
+        def completedActivations = activations.completedactivations
+
+        then:
+        pendingActivations.any { it.featureid == featureId }
+        !completedActivations.any { it.featureid == featureId }
+
+        when:
+        def pendingFeature = pendingActivations.find { it.featureid == featureId } as Map<String, Object>
+
+        then:
+        pendingFeature.featureid == featureId
+        pendingFeature.activationblock == activationBlock
+        pendingFeature.minimumversion == minClientVersion
+    }
+
+    def "Creating trades involving main ecosystem tokens during the grace period is still invalid"() {
+        when:
+        def txid = omniSendTrade(actorAddress, CurrencyID.MSC, startMSC, mainID, 25.0)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        and:
+        omniGetBalance(actorAddress, mainID) == old(omniGetBalance(actorAddress, mainID))
+        omniGetBalance(actorAddress, CurrencyID.MSC) == old(omniGetBalance(actorAddress, CurrencyID.MSC))
+    }
+
+    def "After the successful activation of the feature, the feature activation completed"() {
+        setup:
+        while (getBlockCount() < activationBlock) {
+            generateBlock()
+        }
+
+        when:
+        def activations = omniGetActivations()
+        def pendingActivations = activations.pendingactivations
+        def completedActivations = activations.completedactivations
+
+        then:
+        !pendingActivations.any { it.featureid == featureId }
+        completedActivations.any { it.featureid == featureId }
+
+        when:
+        def activatedFeature = completedActivations.find { it.featureid == featureId } as Map<String, Object>
+
+        then:
+        activatedFeature.featureid == featureId
+        activatedFeature.activationblock == activationBlock
+        activatedFeature.minimumversion == minClientVersion
+
+    }
+
+    def "After the successful activation of the feature, it valid to trade main ecosystem tokens"() {
+        setup:
+        def amountForSale = startMSC
+        def amountDesired = 25.0
+        def balanceAtStart = omniGetBalance(actorAddress, CurrencyID.MSC)
+
+        when:
+        def tradeTxid = omniSendTrade(actorAddress, CurrencyID.MSC, amountForSale, mainID, amountDesired)
+        generateBlock()
+
+        then:
+        omniGetTransaction(tradeTxid).valid
+
+        and:
+        omniGetTrade(tradeTxid).status == "open"
+        omniGetTrade(tradeTxid).amountremaining as BigDecimal == amountForSale
+        omniGetTrade(tradeTxid).amounttofill as BigDecimal == amountDesired
+        omniGetTrade(tradeTxid).amountforsale as BigDecimal == amountForSale
+        omniGetTrade(tradeTxid).amountdesired as BigDecimal == amountDesired
+        omniGetTrade(tradeTxid).propertyidforsale == CurrencyID.MSC.getValue()
+        omniGetTrade(tradeTxid).propertyiddesired == mainID.getValue()
+        omniGetTrade(tradeTxid).propertyidforsaleisdivisible
+        omniGetTrade(tradeTxid).propertyiddesiredisdivisible
+        omniGetTrade(tradeTxid).unitprice == "0.00400000000000000000000000000000000000000000000000"
+
+        and:
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == balanceAtStart.balance - amountForSale
+        omniGetBalance(actorAddress, CurrencyID.MSC).reserved == balanceAtStart.reserved + amountForSale
+
+        when:
+        def cancelTxid = omniSendCancelTradesByPrice(actorAddress, CurrencyID.MSC, amountForSale, mainID, amountDesired)
+        generateBlock()
+
+        then:
+        omniGetTransaction(cancelTxid).valid
+
+        and:
+        omniGetTrade(tradeTxid).status == "cancelled"
+
+        and:
+        omniGetTrade(cancelTxid).propertyidforsale == CurrencyID.MSC.getValue()
+        omniGetTrade(cancelTxid).propertyidforsaleisdivisible
+        omniGetTrade(cancelTxid).amountforsale as BigDecimal == amountForSale
+        omniGetTrade(cancelTxid).propertyiddesired == mainID.getValue()
+        omniGetTrade(cancelTxid).propertyiddesiredisdivisible
+        omniGetTrade(cancelTxid).amountdesired as BigDecimal == amountDesired
+        omniGetTrade(cancelTxid).unitprice == "0.00400000000000000000000000000000000000000000000000"
+
+        and:
+        omniGetBalance(actorAddress, CurrencyID.MSC) == balanceAtStart
+    }
+
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
@@ -4,6 +4,7 @@ import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
 import foundation.omni.PropertyType
 import org.bitcoinj.core.Address
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -16,6 +17,7 @@ import spock.lang.Stepwise
  *
  * Note: this test is only successful with a clean state, and requires that the feature is initially disabled!
  */
+@Ignore('the tests can only be executed with a pristine state, and the MetaDEx is already activated in regtest mode')
 @Stepwise
 class MetaDExActivationSpec extends BaseActivationSpec {
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
@@ -1,11 +1,9 @@
 package foundation.omni.test.rpc.activation
 
-import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
 import foundation.omni.PropertyType
 import org.bitcoinj.core.Address
-import org.junit.internal.AssumptionViolatedException
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -19,13 +17,7 @@ import spock.lang.Stepwise
  * Note: this test is only successful with a clean state, and requires that the feature is initially disabled!
  */
 @Stepwise
-class MetaDExActivationSpec extends BaseRegTestSpec {
-
-    final static Integer minClientVersion = 0
-    final static Integer activationMinBlocks = 5
-    final static Short featureId = 2
-    final static BigDecimal startBTC = 0.1
-    final static BigDecimal startMSC = 0.1
+class MetaDExActivationSpec extends BaseActivationSpec {
 
     @Shared Integer activationBlock = 999999
     @Shared Address actorAddress
@@ -33,10 +25,6 @@ class MetaDExActivationSpec extends BaseRegTestSpec {
     @Shared CurrencyID testID
 
     def setupSpec() {
-        if (!commandExists('omni_sendactivation')) {
-            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
-        }
-
         actorAddress = createFundedAddress(startBTC, startMSC)
         mainID = fundNewProperty(actorAddress, 10.0, PropertyType.DIVISIBLE, Ecosystem.MSC)
         testID = fundNewProperty(actorAddress, 15.0, PropertyType.DIVISIBLE, Ecosystem.TMSC)
@@ -108,7 +96,7 @@ class MetaDExActivationSpec extends BaseRegTestSpec {
         activationBlock = getBlockCount() + activationMinBlocks + 1 // one extra, for transaction confirmation
 
         when:
-        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        def txid = omniSendActivation(actorAddress, metaDExFeatureId, activationBlock, minClientVersion)
         generateBlock()
 
         then:
@@ -120,14 +108,14 @@ class MetaDExActivationSpec extends BaseRegTestSpec {
         def completedActivations = activations.completedactivations
 
         then:
-        pendingActivations.any { it.featureid == featureId }
-        !completedActivations.any { it.featureid == featureId }
+        pendingActivations.any { it.featureid == metaDExFeatureId }
+        !completedActivations.any { it.featureid == metaDExFeatureId }
 
         when:
-        def pendingFeature = pendingActivations.find { it.featureid == featureId } as Map<String, Object>
+        def pendingFeature = pendingActivations.find { it.featureid == metaDExFeatureId } as Map<String, Object>
 
         then:
-        pendingFeature.featureid == featureId
+        pendingFeature.featureid == metaDExFeatureId
         pendingFeature.activationblock == activationBlock
         pendingFeature.minimumversion == minClientVersion
     }
@@ -157,14 +145,14 @@ class MetaDExActivationSpec extends BaseRegTestSpec {
         def completedActivations = activations.completedactivations
 
         then:
-        !pendingActivations.any { it.featureid == featureId }
-        completedActivations.any { it.featureid == featureId }
+        !pendingActivations.any { it.featureid == metaDExFeatureId }
+        completedActivations.any { it.featureid == metaDExFeatureId }
 
         when:
-        def activatedFeature = completedActivations.find { it.featureid == featureId } as Map<String, Object>
+        def activatedFeature = completedActivations.find { it.featureid == metaDExFeatureId } as Map<String, Object>
 
         then:
-        activatedFeature.featureid == featureId
+        activatedFeature.featureid == metaDExFeatureId
         activatedFeature.activationblock == activationBlock
         activatedFeature.minimumversion == minClientVersion
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
@@ -1,0 +1,142 @@
+package foundation.omni.test.rpc.activation
+
+import foundation.omni.BaseRegTestSpec
+import foundation.omni.CurrencyID
+import org.junit.internal.AssumptionViolatedException
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+/**
+ * Specification for the deactivation of "over-offers" on the traditional distributed exchange.
+ *
+ * Once the feature with identifier 5 is active, it is no longer allowed to create offers on the traditional
+ * distributed exchange for an amount that is more than the available balance.
+ *
+ * During the grace period, the old rules are still in place.
+ *
+ * Note: this test is only successful with a clean state!
+ *
+ * After running the tests, the following tests fail:
+ *
+ *   "Offering more tokens than available puts up an offer with the available amount" (in test.rpc.dex.DexSpec)
+ *   "Receiving tokens doesn't increase the offered amount of a published offer" (in test.rpc.dex.DexSpec)
+ */
+@Stepwise
+class OverOfferDeactivationSpec extends BaseRegTestSpec {
+
+    final static Integer minClientVersion = 0
+    final static Integer activationMinBlocks = 5
+    final static Short featureId = 5 // TODO: identifier may change
+    final static BigDecimal startBTC = 0.1
+    final static BigDecimal startMSC = 0.1
+    final static BigDecimal zeroAmount = 0.0
+    final static BigDecimal stdCommitFee = 0.0
+    final static Byte stdBlockSpan = 10
+    final static Byte actionNew = 1
+
+    @Shared Integer activationBlock = 999999
+
+    def setupSpec() {
+        if (!commandExists('omni_sendactivation')) {
+            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
+        }
+    }
+
+    def "Offering more than available on the distributed exchange is valid before the deactivation"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def balanceAtStart = omniGetBalance(actorAddress, CurrencyID.MSC).balance
+        def orderAmount = balanceAtStart * 5 // more than available!
+
+        when:
+        def txid = createDexSellOffer(
+                actorAddress, CurrencyID.MSC, orderAmount, orderAmount, stdBlockSpan, stdCommitFee, actionNew)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).amount as BigDecimal != orderAmount
+        omniGetTransaction(txid).amount as BigDecimal == balanceAtStart // less than offered!
+
+        and:
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        omniGetBalance(actorAddress, CurrencyID.MSC).reserved == balanceAtStart
+    }
+
+    def "Feature identifier 5 can be used to schedule the deactivation of \"over-offers\""() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, zeroAmount)
+        activationBlock = getBlockCount() + activationMinBlocks + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+    }
+
+    def "Offering more than available on the distributed exchange is still valid until the feature activation"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def balanceAtStart = omniGetBalance(actorAddress, CurrencyID.MSC).balance
+        def orderAmount = balanceAtStart * 5 // more than available!
+        def blockBeforeActivation = activationBlock - 1
+
+        while (getBlockCount() < blockBeforeActivation - 1) { // two extra, for transaction confirmation
+            generateBlock()
+        }
+
+        when:
+        def txid = createDexSellOffer(
+                actorAddress, CurrencyID.MSC, orderAmount, orderAmount, stdBlockSpan, stdCommitFee, actionNew)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).amount as BigDecimal != orderAmount
+        omniGetTransaction(txid).amount as BigDecimal == balanceAtStart // less than offered!
+
+        and:
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        omniGetBalance(actorAddress, CurrencyID.MSC).reserved == balanceAtStart
+    }
+
+    def "After the successful activation of the feature, it is no longer valid to offer more than available"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def balanceAtStart = omniGetBalance(actorAddress, CurrencyID.MSC).balance
+        def orderAmount = balanceAtStart * 5 // more than available!
+
+        when:
+        def txid = createDexSellOffer(
+                actorAddress, CurrencyID.MSC, orderAmount, orderAmount, stdBlockSpan, stdCommitFee, actionNew)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        and:
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == balanceAtStart
+        omniGetBalance(actorAddress, CurrencyID.MSC).reserved == zeroAmount
+    }
+
+    def "The activation has no effect on orders, which offer exactly the balance that is available"() {
+        setup:
+        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def orderAmount = omniGetBalance(actorAddress, CurrencyID.MSC).balance
+
+        when:
+        def txid = createDexSellOffer(
+                actorAddress, CurrencyID.MSC, orderAmount, orderAmount, stdBlockSpan, stdCommitFee, actionNew)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+        omniGetTransaction(txid).amount as BigDecimal == orderAmount
+
+        and:
+        omniGetBalance(actorAddress, CurrencyID.MSC).balance == zeroAmount
+        omniGetBalance(actorAddress, CurrencyID.MSC).reserved == orderAmount
+    }
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
@@ -1,6 +1,7 @@
 package foundation.omni.test.rpc.activation
 
 import foundation.omni.CurrencyID
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -19,6 +20,7 @@ import spock.lang.Stepwise
  *   "Offering more tokens than available puts up an offer with the available amount" (in test.rpc.dex.DexSpec)
  *   "Receiving tokens doesn't increase the offered amount of a published offer" (in test.rpc.dex.DexSpec)
  */
+@Ignore('the tests can only be executed with a pristine state, and they affect other exchange related tests')
 @Stepwise
 class OverOfferDeactivationSpec extends BaseActivationSpec {
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
@@ -1,7 +1,6 @@
 package foundation.omni.test.rpc.activation
 
 import foundation.omni.CurrencyID
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -12,15 +11,7 @@ import spock.lang.Stepwise
  * distributed exchange for an amount that is more than the available balance.
  *
  * During the grace period, the old rules are still in place.
- *
- * Note: this test is only successful with a clean state!
- *
- * After running the tests, the following tests fail:
- *
- *   "Offering more tokens than available puts up an offer with the available amount" (in test.rpc.dex.DexSpec)
- *   "Receiving tokens doesn't increase the offered amount of a published offer" (in test.rpc.dex.DexSpec)
  */
-@Ignore('the tests can only be executed with a pristine state, and they affect other exchange related tests')
 @Stepwise
 class OverOfferDeactivationSpec extends BaseActivationSpec {
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
@@ -1,8 +1,6 @@
 package foundation.omni.test.rpc.activation
 
-import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
-import org.junit.internal.AssumptionViolatedException
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -22,25 +20,13 @@ import spock.lang.Stepwise
  *   "Receiving tokens doesn't increase the offered amount of a published offer" (in test.rpc.dex.DexSpec)
  */
 @Stepwise
-class OverOfferDeactivationSpec extends BaseRegTestSpec {
+class OverOfferDeactivationSpec extends BaseActivationSpec {
 
-    final static Integer minClientVersion = 0
-    final static Integer activationMinBlocks = 5
-    final static Short featureId = 5 // TODO: identifier may change
-    final static BigDecimal startBTC = 0.1
-    final static BigDecimal startMSC = 0.1
-    final static BigDecimal zeroAmount = 0.0
-    final static BigDecimal stdCommitFee = 0.0
-    final static Byte stdBlockSpan = 10
-    final static Byte actionNew = 1
+    static final BigDecimal stdCommitFee = 0.0
+    static final Byte stdBlockSpan = 10
+    static final Byte actionNew = 1
 
     @Shared Integer activationBlock = 999999
-
-    def setupSpec() {
-        if (!commandExists('omni_sendactivation')) {
-            throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
-        }
-    }
 
     def "Offering more than available on the distributed exchange is valid before the deactivation"() {
         setup:
@@ -69,7 +55,7 @@ class OverOfferDeactivationSpec extends BaseRegTestSpec {
         activationBlock = getBlockCount() + activationMinBlocks + 1 // one extra, for transaction confirmation
 
         when:
-        def txid = omniSendActivation(actorAddress, featureId, activationBlock, minClientVersion)
+        def txid = omniSendActivation(actorAddress, overOffersFeatureId, activationBlock, minClientVersion)
         generateBlock()
 
         then:

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -708,4 +708,15 @@ public class OmniClient extends BitcoinClient {
         return orders;
     }
 
+    /**
+     * Returns pending and completed feature activations.
+     *
+     * @return Pending and complete feature activations
+     * @since Omni Core 0.0.10
+     */
+    public Map<String, List<Map<String, Object>>> omniGetActivations() throws JsonRPCException, IOException {
+        Map<String, List<Map<String, Object>>> activations = send("omni_getactivations", null);
+        return activations;
+    }
+
 }

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -638,6 +638,24 @@ public class OmniClient extends BitcoinClient {
     }
 
     /**
+     * Activates a protocol feature.
+     *
+     * @param fromAddress  The address to send from
+     * @param featureId    The identifier of the feature to activate
+     * @param block        The activation block
+     * @param minVersion   The minimum supported client version
+     * @return The hash of the transaction
+     * @since Omni Core 0.0.10
+     */
+    public Sha256Hash omniSendActivation(Address fromAddress, Short featureId, Integer block, Integer minVersion)
+            throws JsonRPCException, IOException {
+        List<Object> params = createParamList(fromAddress.toString(), featureId, block, minVersion);
+        String txid = send("omni_sendactivation", params);
+        Sha256Hash hash = Sha256Hash.wrap(txid);
+        return hash;
+    }
+
+    /**
      * Returns information about an order on the distributed token exchange.
      *
      * @param txid The transaction hash of the order to look up


### PR DESCRIPTION
**Add support for RPC "omni_sendactivations" to activate features**

The command can be used to activate protocol features, and is going to be added in Omni Core 0.0.10.

**Add support for RPC "omni_getactivations"**

This command can be used to list pending or completed activations, and is going to be added in Omni Core 0.0.10.

**Add specification for the grace period of feature activations**

Features are activated at specific block heights, which must be within the range of a grace period to ensure users have enough time to update their clients.

The use of activation commands is restricted to whitelisted senders. To whitelist a source to allow feature activations, the option `-omniactivationallowsender="sender"` can be used.

The option `-omniactivationallowsender=any` can be used to remove the restriction.

**Add specification for the deactivation of DEx "over-offers"**

Once the feature with identifier 5 is active, it is no longer allowed to create offers on the traditional distributed exchange, for an amount that is more than the available balance. During the grace period, the old rules are still in place.

**Add specification for the activation of the MetaDEx**

Once the feature with identifier 2 is active, the distributed token exchange can be used with non-test tokens. During the grace period, the old rules are still in place.

**Add base class for feature activation related tests**

The new base class `BaseActivationSpec` is used to ensure that the client-to-test actually has the required RPCs, or otherwise the tests will be skipped.

**Deactivate all feature activation related tests**

Feature activation tests currently affect other tests and can only be executed with a prestine state.

This doesn't play well with automated tests, and may not be obvious, when using OmniJ to run tests via an IDE.

The `MetaDExActivationSpec` only works, if the MetaDEx is not yet activated, which is not the default in Omni Core, even in regtest mode, so it's required to manually un-ignore the specification.

**Add workaround to avoid conflict of activations**

However, to avoid that the activations affect other tests, a workaround is used to revert consensus affecting changes:

Before the tests, the hash of a "marker block" is stored, and after the tests 50 blocks are mined, and finally the "marker block" is invalidated. This results in a reorganization, and because only the state of the last 50 blocks is persisted, it completely resets the state, including all activations inbetween.

This allows to enable 2/3 activation specs.