### PR TITLE
Ignore test for "listproperties_MP" RPC

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ListPropertiesSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ListPropertiesSpec.groovy
@@ -3,6 +3,7 @@ package foundation.omni.test.rpc.basic
 import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
+import spock.lang.Ignore
 
 import static foundation.omni.CurrencyID.MSC
 import static foundation.omni.CurrencyID.TMSC
@@ -11,6 +12,7 @@ import foundation.omni.rpc.SmartPropertyListInfo
 /**
  * Specification for listproperties_MP
  */
+@Ignore("due to incompatibility with Omni Core 0.0.10")
 class ListPropertiesSpec extends BaseRegTestSpec {
 
     def "Returns a property list with correct MSC and TMSC entries"() {


### PR DESCRIPTION
The token description of MSC and TMSC changed in Omni Core 0.0.10, and as result this test breaks the automated testing of Omni Core.

Once Master Core 0.0.9 is depreciated, the test can be updated and re-enabled.

See: https://github.com/OmniLayer/omnicore/pull/217#issuecomment-137170515