### PR TITLE
Update tests to increase coverage of RPC results and core

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CrowdsaleParticipationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/crowdsale/CrowdsaleParticipationSpec.groovy
@@ -31,36 +31,74 @@ class CrowdsaleParticipationSpec extends BaseRegTestSpec {
         */
         def rawTx = "000000330100020000000000004d44697600000000000001000000000000000100000001ccd403f00000"
         def issuerAddress = createFundedAddress(startBTC, startMSC, false)
-        def investorAddress = createFundedAddress(startBTC, amountToInvest, false)
+        def investorAddress = createFundedAddress(startBTC, amountToInvest.bigDecimalValue(), false)
         def currencyMSC = CurrencyID.MSC
 
         when: "creating a new crowdsale with 0.00000001 MDiv per unit invested"
         def crowdsaleTxid = omniSendRawTx(issuerAddress, rawTx)
         generateBlock()
 
-        then: "the crowdsale is active"
+        then: "the crowdsale is valid"
         def crowdsaleTx = omniGetTransaction(crowdsaleTxid)
         crowdsaleTx.confirmations == 1
-        crowdsaleTx.valid == true
+        crowdsaleTx.valid
+
+        and: "the crowdsale is active"
         def propertyId = new CurrencyID(crowdsaleTx.propertyid as Long)
-        omniGetCrowdsale(propertyId).active == true
+        omniGetCrowdsale(propertyId).active
 
         when: "participant invests #amountToInvest MSC"
-        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest)
+        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest.bigDecimalValue())
         generateBlock()
 
         then: "the investor should get #expectedBalance MDiv"
-        omniGetTransaction(sendTxid).valid == true
-        omniGetBalance(investorAddress, propertyId).balance == expectedBalance
+        omniGetBalance(investorAddress, propertyId).balance == expectedBalance.bigDecimalValue()
 
         and: "the issuer receives the invested amount"
-        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
+        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest.bigDecimalValue()
+
+        when: "retrieving the transaction"
+        def sendTx = omniGetTransaction(sendTxid)
+
+        then: "it's a valid crowdsale participation transaction"
+        sendTx.txid == sendTxid.toString()
+        sendTx.sendingaddress == investorAddress.toString()
+        sendTx.referenceaddress == issuerAddress.toString()
+        sendTx.version == 0
+        sendTx.type_int == 0
+        sendTx.type == "Crowdsale Purchase"
+        sendTx.propertyid == currencyMSC.getValue()
+        sendTx.divisible
+        sendTx.amount as BigDecimal == amountToInvest.bigDecimalValue()
+        sendTx.purchasedpropertyid == propertyId.getValue()
+        sendTx.purchasedpropertyname == "MDiv"
+        sendTx.purchasedpropertydivisible
+        sendTx.purchasedtokens as BigDecimal == expectedBalance.bigDecimalValue()
+        sendTx.issuertokens as BigDecimal == 0.0 // no bonus applied
+        sendTx.valid
+
+        when: "retrieving information about the crowdsale"
+        def crowdsale = omniGetCrowdsale(propertyId)
+
+        then: "the information matches the initial creation"
+        crowdsale.propertyid == propertyId.getValue()
+        crowdsale.name == "MDiv"
+        crowdsale.active
+        crowdsale.issuer == issuerAddress.toString()
+        crowdsale.propertyiddesired == currencyMSC.getValue()
+        crowdsale.tokensperunit as BigDecimal == 0.00000001.divisible.bigDecimalValue()
+        crowdsale.earlybonus == 0
+        crowdsale.percenttoissuer == 0
+        crowdsale.deadline == 7731414000
+        crowdsale.tokensissued as BigDecimal == expectedBalance.bigDecimalValue()
+        crowdsale.addedissuertokens as BigDecimal == 0.divisible.bigDecimalValue() // no bonus applied
+
 
         where:
-        amountToInvest | expectedBalance
-        0.00000001     | 0.0
-        1.0            | 0.00000001
-        2.99999999     | 0.00000002
+        amountToInvest       | expectedBalance
+        0.00000001.divisible | 0.0.divisible
+        1.0.divisible        | 0.00000001.divisible
+        2.99999999.divisible | 0.00000002.divisible
     }
 
     @Unroll
@@ -85,36 +123,77 @@ class CrowdsaleParticipationSpec extends BaseRegTestSpec {
         */
         def rawTx = "000000330100020000000000004d446976000000000000017fffffffffffffff00000001ccd403f00000"
         def issuerAddress = createFundedAddress(startBTC, startMSC, false)
-        def investorAddress = createFundedAddress(startBTC, amountToInvest, false)
+        def investorAddress = createFundedAddress(startBTC, amountToInvest.bigDecimalValue(), false)
         def currencyMSC = CurrencyID.MSC
 
         when: "creating a new crowdsale with 0.00000001 MDiv per unit invested"
         def crowdsaleTxid = omniSendRawTx(issuerAddress, rawTx)
         generateBlock()
 
-        then: "the crowdsale is active"
+        then: "the crowdsale is valid"
         def crowdsaleTx = omniGetTransaction(crowdsaleTxid)
         crowdsaleTx.confirmations == 1
-        crowdsaleTx.valid == true
+        crowdsaleTx.valid
+
+        and: "the crowdsale is active"
         def propertyId = new CurrencyID(crowdsaleTx.propertyid as Long)
-        omniGetCrowdsale(propertyId).active == true
+        omniGetCrowdsale(propertyId).active
 
         when: "participant invests #amountToInvest MSC"
-        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest)
+        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest.bigDecimalValue())
         generateBlock()
 
         then: "the investor should get #expectedBalance MDiv"
-        omniGetTransaction(sendTxid).valid == true
-        omniGetBalance(investorAddress, propertyId).balance == expectedBalance
+        omniGetBalance(investorAddress, propertyId).balance == expectedBalance.bigDecimalValue()
 
         and: "the issuer receives the invested amount"
-        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
+        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest.bigDecimalValue()
+
+        when: "retrieving the transaction"
+        def sendTx = omniGetTransaction(sendTxid)
+
+        then: "it's a valid crowdsale participation transaction"
+        sendTx.txid == sendTxid.toString()
+        sendTx.sendingaddress == investorAddress.toString()
+        sendTx.referenceaddress == issuerAddress.toString()
+        sendTx.version == 0
+        sendTx.type_int == 0
+        sendTx.type == "Crowdsale Purchase"
+        sendTx.propertyid == currencyMSC.getValue()
+        sendTx.divisible
+        sendTx.amount as BigDecimal == amountToInvest.bigDecimalValue()
+        sendTx.purchasedpropertyid == propertyId.getValue()
+        sendTx.purchasedpropertyname == "MDiv"
+        sendTx.purchasedpropertydivisible
+        sendTx.purchasedtokens as BigDecimal == expectedBalance.bigDecimalValue()
+        sendTx.issuertokens as BigDecimal == 0.0 // no bonus applied
+        sendTx.valid
+
+        when: "retrieving information about the crowdsale"
+        def crowdsale = omniGetCrowdsale(propertyId)
+
+        then: "the information matches the initial creation"
+        crowdsale.propertyid == propertyId.getValue()
+        crowdsale.name == "MDiv"
+        crowdsale.active == !crowdsaleMaxed
+        crowdsale.issuer == issuerAddress.toString()
+        crowdsale.propertyiddesired == currencyMSC.getValue()
+        crowdsale.tokensperunit as BigDecimal == 92233720368.54775807.divisible.bigDecimalValue()
+        crowdsale.earlybonus == 0
+        crowdsale.percenttoissuer == 0
+        crowdsale.deadline == 7731414000
+        if (crowdsaleMaxed) {
+            assert crowdsale.closedearly
+            assert crowdsale.maxtokens
+        }
+        crowdsale.tokensissued as BigDecimal == expectedBalance.bigDecimalValue()
+        crowdsale.addedissuertokens as BigDecimal == 0.divisible.bigDecimalValue() // no bonus applied
 
         where:
-        amountToInvest | expectedBalance
-        0.01           | 922337203.68547758
-        1.0            | 92233720368.54775807
-        2.0            | 92233720368.54775807 // Cap of 2^63-1 issued units reached!
+        amountToInvest | expectedBalance                | crowdsaleMaxed
+        0.01.divisible | 922337203.68547758.divisible   | false
+        1.0.divisible  | 92233720368.54775807.divisible | false
+        2.0.divisible  | 92233720368.54775807.divisible | true // Cap of 2^63-1 issued units reached!
     }
 
     @Unroll
@@ -139,35 +218,72 @@ class CrowdsaleParticipationSpec extends BaseRegTestSpec {
         */
         def rawTx = "0000003301000100000000000054496e646976000000000000020000000000000d4800000001ccd403f00000"
         def issuerAddress = createFundedAddress(startBTC, startMSC, false)
-        def investorAddress = createFundedAddress(startBTC, amountToInvest, false)
+        def investorAddress = createFundedAddress(startBTC, amountToInvest.bigDecimalValue(), false)
         def currencyMSC = CurrencyID.TMSC
 
         when: "creating a new crowdsale with 3400 TIndiv per unit invested"
         def crowdsaleTxid = omniSendRawTx(issuerAddress, rawTx)
         generateBlock()
 
-        then: "the crowdsale is active"
+        then: "the crowdsale is valid"
         def crowdsaleTx = omniGetTransaction(crowdsaleTxid)
         crowdsaleTx.confirmations == 1
-        crowdsaleTx.valid == true
+        crowdsaleTx.valid
+
+        and: "the crowdsale is active"
         def propertyId = new CurrencyID(crowdsaleTx.propertyid as Long)
-        omniGetCrowdsale(propertyId).active == true
+        omniGetCrowdsale(propertyId).active
 
         when: "participant invests #amountToInvest TMSC"
-        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest)
+        def sendTxid = omniSend(investorAddress, issuerAddress, currencyMSC, amountToInvest.bigDecimalValue())
         generateBlock()
 
         then: "the investor should get #expectedBalance TIndiv"
-        omniGetTransaction(sendTxid).valid == true
-        omniGetBalance(investorAddress, propertyId).balance == expectedBalance as BigDecimal
+        omniGetBalance(investorAddress, propertyId).balance == expectedBalance.bigDecimalValue()
 
         and: "the issuer receives the invested amount"
-        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest
+        omniGetBalance(issuerAddress, currencyMSC).balance == startMSC + amountToInvest.bigDecimalValue()
+
+        when: "retrieving the transaction"
+        def sendTx = omniGetTransaction(sendTxid)
+
+        then: "it's a valid crowdsale participation transaction"
+        sendTx.txid == sendTxid.toString()
+        sendTx.sendingaddress == investorAddress.toString()
+        sendTx.referenceaddress == issuerAddress.toString()
+        sendTx.version == 0
+        sendTx.type_int == 0
+        sendTx.type == "Crowdsale Purchase"
+        sendTx.propertyid == currencyMSC.getValue()
+        sendTx.divisible
+        sendTx.amount as BigDecimal == amountToInvest.bigDecimalValue()
+        sendTx.purchasedpropertyid == propertyId.getValue()
+        sendTx.purchasedpropertyname == "TIndiv"
+        !sendTx.purchasedpropertydivisible
+        sendTx.purchasedtokens as BigDecimal == expectedBalance.bigDecimalValue()
+        sendTx.issuertokens as BigDecimal == 0.0 // no bonus applied
+        sendTx.valid
+
+        when: "retrieving information about the crowdsale"
+        def crowdsale = omniGetCrowdsale(propertyId)
+
+        then: "the information matches the initial creation"
+        crowdsale.propertyid == propertyId.getValue()
+        crowdsale.name == "TIndiv"
+        crowdsale.active
+        crowdsale.issuer == issuerAddress.toString()
+        crowdsale.propertyiddesired == currencyMSC.getValue()
+        crowdsale.tokensperunit as BigDecimal == 3400.indivisible.bigDecimalValue()
+        crowdsale.earlybonus == 0
+        crowdsale.percenttoissuer == 0
+        crowdsale.deadline == 7731414000
+        crowdsale.tokensissued as BigDecimal == expectedBalance.bigDecimalValue()
+        crowdsale.addedissuertokens as BigDecimal == 0.divisible.bigDecimalValue() // no bonus applied
 
         where:
-        amountToInvest | expectedBalance
-        0.0025         | 8
-        0.005          | 17
+        amountToInvest   | expectedBalance
+        0.0025.divisible | 8.indivisible
+        0.005.divisible  | 17.indivisible
     }
 
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/dex/DexVersionsSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/dex/DexVersionsSpec.groovy
@@ -1,0 +1,122 @@
+package foundation.omni.test.rpc.dex
+
+import com.msgilligan.bitcoinj.rpc.JsonRPCStatusException
+import foundation.omni.BaseRegTestSpec
+
+/**
+ * Transaction format tests for traditional DEx offer
+ *
+ * Traditional DEx orders with version 0 have an implicit action value,
+ * based on the global state, whereby transactions with version 1 have an
+ * explicit action value. Other versions are currently not valid.
+ */
+class DexVersionsSpec extends BaseRegTestSpec {
+
+    def "DEx transactions with version 0 have no explicit action value"() {
+        /*
+            {
+                "version": 0,
+                "type_int": 20,
+                "propertyid": 1,
+                "amount": "0.40000000",currently
+                "bitcoindesired": "0.80000000",
+                "timelimit": 15,
+                "feerequired": "0.00000100"
+            }
+        */
+        def rawTx = "00000014000000010000000002625a000000000004c4b4000f0000000000000064"
+        def actorAddress = createFundedAddress(0.001.btc, 0.5.divisible)
+
+        when:
+        def txid = omniSendRawTx(actorAddress, rawTx)
+        generateBlock()
+
+        and:
+        def offerTx = omniGetTransaction(txid)
+
+        then:
+        offerTx.action == "new" // implicit
+        offerTx.valid
+    }
+
+    def "DEx transactions with version 1 have an explicit action value"() {
+        /*
+            {
+                "version": 1,
+                "type_int": 20,
+                "propertyid": 2,
+                "amount": "0.10000000",
+                "bitcoindesired": "0.10000000",
+                "timelimit": 20,
+                "feerequired": "0.00000000",
+                "action": 1
+            }
+        */
+        def rawTx = "00010014000000020000000000989680000000000098968014000000000000000001"
+        def actorAddress = createFundedAddress(0.001.btc, 0.3.divisible)
+
+        when:
+        def txid = omniSendRawTx(actorAddress, rawTx)
+        generateBlock()
+
+        and:
+        def offerTx = omniGetTransaction(txid)
+
+        then:
+        offerTx.action == "new" // explicit
+        offerTx.valid
+    }
+
+    def "DEx transactions with version 1 must be sent with action value"() {
+        /*
+            {
+                "version": 1,
+                "type_int": 20,
+                "propertyid": 1,
+                "amount": "0.30000000",
+                "bitcoindesired": "0.30000000",
+                "timelimit": 7,
+                "feerequired": "0.00000050"
+            }
+        */
+        def rawTx = "00010014000000010000000001c9c3800000000001c9c380070000000000000032"
+        def actorAddress = createFundedAddress(0.001.btc, 0.3.divisible)
+
+        when:
+        def txid = omniSendRawTx(actorAddress, rawTx)
+        generateBlock()
+
+        and:
+        omniGetTransaction(txid)
+
+        then:
+        thrown(JsonRPCStatusException) // No Omni transaction
+    }
+
+    def "DEx transactions with versions greater than 1 are currently not valid"() {
+        /*
+            {
+                "version": 2,
+                "type_int": 20,
+                "propertyid": 2,
+                "amount": "0.00000001",
+                "bitcoindesired": "0.00000001",
+                "timelimit": 255,
+                "feerequired": "0.00000001",
+                "action": 1
+            }
+        */
+        def rawTx = "000200140000000100000000000000010000000000000001ff000000000000000101"
+        def actorAddress = createFundedAddress(0.001.btc, 0.001.divisible)
+
+        when:
+        def txid = omniSendRawTx(actorAddress, rawTx)
+        generateBlock()
+
+        and:
+        def offerTx = omniGetTransaction(txid)
+
+        then:
+        !offerTx.valid
+    }
+}

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 // TODO: add missing RPCs:
 // - listtransactions_MP
-// - getsto_MP
 // - omni_gettradehistoryforpair
 // - omni_gettradehistoryforaddress
 
@@ -653,6 +652,19 @@ public class OmniClient extends BitcoinClient {
         String txid = send("omni_sendactivation", params);
         Sha256Hash hash = Sha256Hash.wrap(txid);
         return hash;
+    }
+
+    /**
+     * Get information and recipients of a send-to-owners transaction.
+     *
+     * @param txid  The hash of the transaction to lookup
+     * @return Information about the transaction
+     */
+    public Map<String, Object> omniGetSTO(Sha256Hash txid) throws JsonRPCException, IOException {
+        String filter = "*"; // no filter at all
+        List<Object> params = createParamList(txid.toString(), filter);
+        Map<String, Object> stoInfo = send("getsto_MP", params);
+        return stoInfo;
     }
 
     /**


### PR DESCRIPTION
The new or updated tests cover some of the pitfalls we recently had with Omni Core.

In particular:

- https://github.com/OmniLayer/omnicore/issues/242 Reorg containing STO corrupts STODB data
- https://github.com/OmniLayer/omnicore/pull/187#issuecomment-133244564 Reorg may cause token IDs to drift
- https://github.com/OmniLayer/omnicore/issues/235 Crowdsale participations being classified as simple sends
- https://github.com/OmniLayer/omnicore/issues/241 Action of DEx orders differs between 0.0.9 and 0.0.10
- https://github.com/OmniLayer/omnicore/commit/5d550f0aa068685703423169684c4742ac03ceaa Add special handling when parsing v0 trade offers
- https://github.com/OmniLayer/omnicore/issues/200 Remaining amount of MetaDEx trade is not updated

There are a few related improvements, which I tackled on the way. See the commits for more details. :)