### PR TITLE
Improve handling of integration tests and feature activations

### DIFF
--- a/omnij-rpc/build.gradle
+++ b/omnij-rpc/build.gradle
@@ -35,39 +35,59 @@ sourceSets {
     }
 }
 
-task integrationTest(type: Test) {
-    testClassesDir = sourceSets.integrationTest.output.classesDir
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
-    testLogging.showStandardStreams = true
-}
-
-task regTest(type: Test) {
-    testClassesDir = sourceSets.integrationTest.output.classesDir
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
-    testLogging.showStandardStreams = true
-    beforeSuite { descriptor ->
-        if (descriptor.getClassName() != null) {
-            logger.lifecycle('\033[1m' + descriptor.getName() + "\033[0m") // bold
+/** Base class for integration tests
+ */
+class IntegrationTest extends Test {
+    public IntegrationTest() {
+        testClassesDir = project.sourceSets.integrationTest.output.classesDir
+        classpath = project.sourceSets.integrationTest.runtimeClasspath
+        outputs.upToDateWhen { false }
+        testLogging {
+            showStandardStreams = true
+            exceptionFormat = 'full'
+            displayGranularity = -1
+        }
+        beforeSuite { descriptor ->
+            if (descriptor.className != null) {
+                logger.lifecycle("\033[1m$descriptor.name\033[0m") // bold
+            }
+        }
+        beforeTest { descriptor ->
+            logger.lifecycle("    $descriptor.name")
         }
     }
-    beforeTest { descriptor ->
-        logger.lifecycle('    ' + descriptor.getName())
-    }
-
-    systemProperty 'regtest', true
-    systemProperties ([ "omni.test.rpcTestUser": rpcTestUser,
-                        "omni.test.rpcTestPassword": rpcTestPassword,
-    ])
-    include 'foundation/omni/test/rpc/**', 'foundation/omni/test/tx/**'
 }
 
-task consensusTest(type: Test) {
-    testClassesDir = sourceSets.integrationTest.output.classesDir
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
-    testLogging.showStandardStreams = true
+/** Base class for integration tests in regtest mode
+ */
+class RegTest extends IntegrationTest {
+    public RegTest() {
+        systemProperty 'regtest', true
+        systemProperties ([ 'omni.test.rpcTestUser': project.rpcTestUser,
+                            'omni.test.rpcTestPassword': project.rpcTestPassword,
+        ])
+    }
+}
+
+task integrationTest(type: IntegrationTest) {
+    description = 'Runs Bitcoin and Omni Core integration tests.'
+}
+
+task activationRegTest(type: RegTest) {
+    description = 'Tests Omni Protocol feature activations in regtest mode.'
+
+    include 'foundation/omni/test/rpc/activation/*'
+}
+
+task regTest(type: RegTest, dependsOn: 'activationRegTest') {
+    description = 'Tests Omni Core RPC calls against an instance of omnicored running in regtest mode.'
+
+    include 'foundation/omni/test/rpc/**', 'foundation/omni/test/tx/**'
+    exclude 'foundation/omni/test/rpc/activation/*'
+}
+
+task consensusTest(type: IntegrationTest) {
+    description = 'Compares balances for multiple Omni Protocol currencies against public data providers.'
 
     systemProperty 'regtest', false
     systemProperties ([ "omni.test.rpcTestUser": rpcTestUser,
@@ -78,5 +98,3 @@ task consensusTest(type: Test) {
     ])
     include 'foundation/omni/test/consensus/**'
 }
-
-

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
@@ -60,4 +60,14 @@ abstract class BaseActivationSpec extends BaseRegTestSpec {
         clearMemPool()
         generateBlock()
     }
+
+    def skipIfActivated(def featureId) {
+        def activations = omniGetActivations()
+        if (activations.pendingactivations.any( { it.featureid == featureId } )) {
+            throw new AssumptionViolatedException("Feature $featureId is already activated")
+        }
+        if (activations.completedactivations.any( { it.featureid == featureId } )) {
+            throw new AssumptionViolatedException("Feature $featureId is already live")
+        }
+    }
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/GracePeriodSpec.groovy
@@ -12,6 +12,10 @@ import spock.lang.Unroll
  */
 class GracePeriodSpec extends BaseActivationSpec {
 
+    def beforeSpec() {
+        skipIfActivated(unallocatedFeatureId)
+    }
+
     @Unroll
     def "A relative activation height of #blockOffset blocks is smaller than the grace period and not allowed"() {
         setup:

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExActivationSpec.groovy
@@ -26,6 +26,10 @@ class MetaDExActivationSpec extends BaseActivationSpec {
     @Shared CurrencyID mainID
     @Shared CurrencyID testID
 
+    def beforeSpec() {
+        skipIfActivated(metaDExFeatureId)
+    }
+
     def setupSpec() {
         actorAddress = createFundedAddress(startBTC, startMSC)
         mainID = fundNewProperty(actorAddress, 10.0, PropertyType.DIVISIBLE, Ecosystem.MSC)

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/OverOfferDeactivationSpec.groovy
@@ -21,6 +21,10 @@ class OverOfferDeactivationSpec extends BaseActivationSpec {
 
     @Shared Integer activationBlock = 999999
 
+    def beforeSpec() {
+        skipIfActivated(overOffersFeatureId)
+    }
+
     def "Offering more than available on the distributed exchange is valid before the deactivation"() {
         setup:
         def actorAddress = createFundedAddress(startBTC, startMSC)

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -68,7 +68,7 @@ trait OmniTestSupport implements BTCTestSupport, OmniClientDelegate, RawTxDelega
             // transaction fee, have to be paid twice
             BigDecimal additionalRequiredDecimal = (dustForExodus + dustForReference + dustForPayload + stdTxFee.value) * 2
             Coin additionalRequired = additionalRequiredDecimal.satoshi
-            println "requestMSC: requesting ${additionalRequired} additional bitcoin"
+            log.debug "requestMSC: requesting ${additionalRequired} additional bitcoin"
             requestBitcoin(toAddress, additionalRequired)
 
             // The excessive amount of MSC is sent to a new address to get rid of it


### PR DESCRIPTION
Activating a feature more than once is not allowed, and the activation tests are skipped, if the feature to test is already activated.

Feature activation tests are split into a seperate task, which is executed before running the `:omnij-rpc:regTest` task. This ensures features, if necessary, are activated before the tests are executed, which may depend on the feature.

The new class `IntegrationTest` is used to set reusable properties, such as the test log formatting, and the new class `RegTest` is intended to be used for RPC tests in regtest mode.

Test failures are described in greater detail, in a similar fashion as in the test reports, where the actual cause (e.g. a failed condition) is printed:
```
...
foundation.omni.test.rpc.basic.ConsensusSpec
    Check all balances
    Check all balances, raw CLI, type Long
    Throw exception checking all balances, raw CLI, type String
foundation.omni.test.rpc.basic.OutputDemonstrationSpec
    On failure, details are printed

On failure, details are printed FAILED
    Condition not satisfied:

    omniGetBalance(actorAddress, CurrencyID.MSC).balance == 9000.0
    |              |                        |    |       |
    |              |                        |    0E-8    false
    |              |                        CurrencyID:1
    |              mkRAcTcvDvJ8SHiMQXrFCxGpBWmjMJ6CpT
    foundation.omni.rpc.MPBalanceEntry@392ddcf2
        at foundation.omni.test.rpc.basic.OutputDemonstrationSpec.On failure, details ...
foundation.omni.test.rpc.basic.SendRawTransactionSpec
    Create raw transaction with reference address
    ...
```

This resolves #106.