### PR TITLE
Explicitly set transaction and relay fees for regtests

### DIFF
--- a/test-omni-integ-regtest.sh
+++ b/test-omni-integ-regtest.sh
@@ -27,7 +27,7 @@ ln -sf $MSCLOG $LOGDIR/mastercore.log
 rm -rf $DATADIR/regtest
 
 # Run omnicored in regtest mode
-$BTCD -regtest -datadir=$DATADIR -omnialertallowsender=any -omniactivationallowsender=any > $LOGDIR/bitcoin.log &
+$BTCD -regtest -datadir=$DATADIR -omnialertallowsender=any -omniactivationallowsender=any -paytxfee=0.0001 -minrelaytxfee=0.00001 > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!
 


### PR DESCRIPTION
The minimum relay fee was temporarily raised to make it harder to spam and bloat the mempool. This however conflicts with some regtests, so fixed/reference fees are explicitly provided.

Related: https://github.com/OmniLayer/omnicore/pull/263