### PR TITLE
Add activation and trading tests for all-pair trading

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/AllPairDExActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/AllPairDExActivationSpec.groovy
@@ -1,0 +1,168 @@
+package foundation.omni.test.rpc.activation
+
+import foundation.omni.CurrencyID
+import foundation.omni.Ecosystem
+import org.bitcoinj.core.Address
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+/**
+ * Specification for the activation of the all pair trading of the distributed token exchange.
+ *
+ * Once the feature with identifier 8 is active, the distributed token exchange can be used with non-Omni tokens.
+ *
+ * During the grace period, the old rules are still in place.
+ *
+ * Note: this test is only successful with a clean state, and requires that the feature is initially disabled!
+ */
+@Stepwise
+class AllPairDExActivationSpec extends BaseActivationSpec {
+
+    @Shared Integer activationBlock = 999999
+    @Shared Address actorAddress
+    @Shared CurrencyID tokenA
+    @Shared CurrencyID tokenB
+
+    def beforeSpec() {
+        skipIfActivated(allPairDExFeatureId)
+    }
+
+    def setupSpec() {
+        actorAddress = createFundedAddress(startBTC, startMSC)
+        tokenA = fundNewProperty(actorAddress, 445.indivisible, Ecosystem.MSC)
+        tokenB = fundNewProperty(actorAddress, 20.indivisible, Ecosystem.MSC)
+    }
+
+    def "Creating trades involving two non-Omni pairs before the activation is invalid"() {
+        when:
+        def txid = omniSendTrade(actorAddress, tokenA, 445.indivisible, tokenB, 20.indivisible)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        and:
+        omniGetBalance(actorAddress, tokenA) == old(omniGetBalance(actorAddress, tokenA))
+        omniGetBalance(actorAddress, tokenB) == old(omniGetBalance(actorAddress, tokenB))
+    }
+
+    def "Feature identifier 8 can be used to schedule the activation of non-Omni pair trading"() {
+        setup:
+        activationBlock = getBlockCount() + activationMinBlocks + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, allPairDExFeatureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+
+        when:
+        def activations = omniGetActivations()
+        def pendingActivations = activations.pendingactivations
+        def completedActivations = activations.completedactivations
+
+        then:
+        pendingActivations.any { it.featureid == allPairDExFeatureId }
+        !completedActivations.any { it.featureid == allPairDExFeatureId }
+
+        when:
+        def pendingFeature = pendingActivations.find { it.featureid == allPairDExFeatureId } as Map<String, Object>
+
+        then:
+        pendingFeature.featureid == allPairDExFeatureId
+        pendingFeature.activationblock == activationBlock
+        pendingFeature.minimumversion == minClientVersion
+    }
+
+    def "Creating trades involving non-Omni tokens during the grace period is still invalid"() {
+        when:
+        def txid = omniSendTrade(actorAddress, tokenA, 445.indivisible, tokenB, 20.indivisible)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid == false
+
+        and:
+        omniGetBalance(actorAddress, tokenA) == old(omniGetBalance(actorAddress, tokenA))
+        omniGetBalance(actorAddress, tokenB) == old(omniGetBalance(actorAddress, tokenB))
+    }
+
+    def "After the successful activation of the feature, the feature activation completed"() {
+        setup:
+        while (getBlockCount() < activationBlock) {
+            generateBlock()
+        }
+
+        when:
+        def activations = omniGetActivations()
+        def pendingActivations = activations.pendingactivations
+        def completedActivations = activations.completedactivations
+
+        then:
+        !pendingActivations.any { it.featureid == allPairDExFeatureId }
+        completedActivations.any { it.featureid == allPairDExFeatureId }
+
+        when:
+        def activatedFeature = completedActivations.find { it.featureid == allPairDExFeatureId } as Map<String, Object>
+
+        then:
+        activatedFeature.featureid == allPairDExFeatureId
+        activatedFeature.activationblock == activationBlock
+        activatedFeature.minimumversion == minClientVersion
+
+    }
+
+    def "After the successful activation of the feature, it valid to trade non-Omni tokens"() {
+        setup:
+        def amountForSale = 2.indivisible
+        def amountDesired = 4.indivisible
+        def balanceAtStart = omniGetBalance(actorAddress, tokenA)
+
+        when:
+        def tradeTxid = omniSendTrade(actorAddress, tokenA, amountForSale, tokenB, amountDesired)
+        generateBlock()
+
+        then:
+        omniGetTransaction(tradeTxid).valid
+
+        and:
+        omniGetTrade(tradeTxid).status == "open"
+        omniGetTrade(tradeTxid).amountremaining as Long == amountForSale.numberValue()
+        omniGetTrade(tradeTxid).amounttofill as Long == amountDesired.numberValue()
+        omniGetTrade(tradeTxid).amountforsale as Long == amountForSale.numberValue()
+        omniGetTrade(tradeTxid).amountdesired as Long == amountDesired.numberValue()
+        omniGetTrade(tradeTxid).propertyidforsale == tokenA.getValue()
+        omniGetTrade(tradeTxid).propertyiddesired == tokenB.getValue()
+        !omniGetTrade(tradeTxid).propertyidforsaleisdivisible
+        !omniGetTrade(tradeTxid).propertyiddesiredisdivisible
+        omniGetTrade(tradeTxid).unitprice == "2.00000000000000000000000000000000000000000000000000"
+
+        and:
+        omniGetBalance(actorAddress, tokenA).balance == balanceAtStart.balance - amountForSale
+        omniGetBalance(actorAddress, tokenA).reserved == balanceAtStart.reserved + amountForSale
+
+        when:
+        def cancelTxid = omniSendCancelTradesByPrice(actorAddress, tokenA, amountForSale, tokenB, amountDesired)
+        generateBlock()
+
+        then:
+        omniGetTransaction(cancelTxid).valid
+
+        and:
+        omniGetTrade(tradeTxid).status == "cancelled"
+
+        and:
+        omniGetTrade(cancelTxid).propertyidforsale == tokenA.getValue()
+        !omniGetTrade(cancelTxid).propertyidforsaleisdivisible
+        omniGetTrade(cancelTxid).amountforsale as Long == amountForSale.numberValue()
+        omniGetTrade(cancelTxid).propertyiddesired == tokenB.getValue()
+        !omniGetTrade(cancelTxid).propertyiddesiredisdivisible
+        omniGetTrade(cancelTxid).amountdesired as Long == amountDesired.numberValue()
+        omniGetTrade(cancelTxid).unitprice == "2.00000000000000000000000000000000000000000000000000"
+
+        and:
+        omniGetBalance(actorAddress, tokenA) == balanceAtStart
+    }
+
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/AllPairDExActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/AllPairDExActivationSpec.groovy
@@ -26,6 +26,7 @@ class AllPairDExActivationSpec extends BaseActivationSpec {
 
     def beforeSpec() {
         skipIfActivated(allPairDExFeatureId)
+        skipIfVersionOlderThan(1100000)
     }
 
     def setupSpec() {

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
@@ -73,4 +73,12 @@ abstract class BaseActivationSpec extends BaseRegTestSpec {
             throw new AssumptionViolatedException("Feature $featureId is already live")
         }
     }
+
+    def skipIfVersionOlderThan(def minClientVersion) {
+        def clientInfo = omniGetInfo()
+        def clientVersion = clientInfo.omnicoreversion_int
+        if (clientVersion < minClientVersion) {
+            throw new AssumptionViolatedException("Requires at least version $minClientVersion, but is $clientVersion")
+        }
+    }
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
@@ -29,6 +29,7 @@ abstract class BaseActivationSpec extends BaseRegTestSpec {
     static final protected Short metaDExFeatureId = 2
     static final protected Short unallocatedFeatureId = 3
     static final protected Short overOffersFeatureId = 5
+    static final protected Short allPairDExFeatureId = 8
 
     // Default values
     static protected Integer minClientVersion = 0

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
@@ -72,7 +72,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         txTradeC.amountforsale as BigDecimal == 0.00000001.divisible.bigDecimalValue()
         txTradeC.propertyiddesired == propertySPX.getValue()
         txTradeC.amountdesired as BigDecimal == 10.indivisible.bigDecimalValue()
-        txTradeC.unitprice == "0.00000000100000000000000000000000000000000000000000"
+        txTradeC.unitprice == "1000000000.00000000000000000000000000000000000000000000000000"
         txTradeC.amountremaining as BigDecimal == 0.00000001.divisible.bigDecimalValue()
         txTradeC.amounttofill as BigDecimal == 10.indivisible.bigDecimalValue()
         txTradeC.matches.size == 0
@@ -138,7 +138,7 @@ class MetaDexSpec extends BaseRegTestSpec {
         txTradeB.amountforsale as BigDecimal == 0.55.divisible.bigDecimalValue()
         txTradeB.propertyiddesired == propertySPX.getValue()
         txTradeB.amountdesired as BigDecimal == 5.indivisible.bigDecimalValue()
-        txTradeB.unitprice == "0.11000000000000000000000000000000000000000000000000"
+        txTradeB.unitprice == "9.09090909090909090909090909090909090909090909090909"
         txTradeB.amountremaining as BigDecimal == 0.05.divisible.bigDecimalValue()
         txTradeB.amounttofill as BigDecimal == 1.indivisible.bigDecimalValue()
         txTradeB.matches.size == 1

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/mdex/MetaDexSpec.groovy
@@ -72,10 +72,14 @@ class MetaDexSpec extends BaseRegTestSpec {
         txTradeC.amountforsale as BigDecimal == 0.00000001.divisible.bigDecimalValue()
         txTradeC.propertyiddesired == propertySPX.getValue()
         txTradeC.amountdesired as BigDecimal == 10.indivisible.bigDecimalValue()
-        txTradeC.unitprice == "1000000000.00000000000000000000000000000000000000000000000000"
         txTradeC.amountremaining as BigDecimal == 0.00000001.divisible.bigDecimalValue()
         txTradeC.amounttofill as BigDecimal == 10.indivisible.bigDecimalValue()
         txTradeC.matches.size == 0
+        if (omniGetInfo().omnicoreversion_int < 1100000) {
+            assert txTradeC.unitprice == "0.00000000100000000000000000000000000000000000000000"
+        } else {
+            assert txTradeC.unitprice == "1000000000.00000000000000000000000000000000000000000000000000"
+        }
     }
 
     /**
@@ -138,10 +142,14 @@ class MetaDexSpec extends BaseRegTestSpec {
         txTradeB.amountforsale as BigDecimal == 0.55.divisible.bigDecimalValue()
         txTradeB.propertyiddesired == propertySPX.getValue()
         txTradeB.amountdesired as BigDecimal == 5.indivisible.bigDecimalValue()
-        txTradeB.unitprice == "9.09090909090909090909090909090909090909090909090909"
         txTradeB.amountremaining as BigDecimal == 0.05.divisible.bigDecimalValue()
         txTradeB.amounttofill as BigDecimal == 1.indivisible.bigDecimalValue()
         txTradeB.matches.size == 1
+        if (omniGetInfo().omnicoreversion_int < 1100000) {
+            assert txTradeB.unitprice == "0.11000000000000000000000000000000000000000000000000"
+        } else {
+            assert txTradeB.unitprice == "9.09090909090909090909090909090909090909090909090909"
+        }
 
         when:
         def tradeMatchB = txTradeB.matches.find { it.txid == txidTradeA.toString() } as Map<String, Object>


### PR DESCRIPTION
This pull request adds tests for the trading of non-Omni pairs.

Once the feature with identifier 8 is active, the distributed token exchange can be used with non-Omni tokens.

During the grace period, the old rules are still in place.

Please note: unfortunally unit prices are no longer nominated in Omni, but instead based on forsale/desired, which is different from our release version.

@msgilligan: ~~currently I simply assume the tests are run with an Omni Core version with the feature and the updated unit price meaning (currently pending as  https://github.com/OmniLayer/omnicore/pull/361), but the tests will fail with 0.0.10. What do you suggest to tackle this? Ideally we'd provide compatibility for both versions.~~