### PR TITLE
Add RPCs and activation test for fee distribution system

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
@@ -30,6 +30,7 @@ abstract class BaseActivationSpec extends BaseRegTestSpec {
     static final protected Short unallocatedFeatureId = 3
     static final protected Short overOffersFeatureId = 5
     static final protected Short allPairDExFeatureId = 8
+    static final protected Short metaDExFeesFeatureId = 9
 
     // Default values
     static protected Integer minClientVersion = 0

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExFeesActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/MetaDExFeesActivationSpec.groovy
@@ -1,0 +1,109 @@
+package foundation.omni.test.rpc.activation
+
+import foundation.omni.Ecosystem
+import org.bitcoinj.core.Address
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+/**
+ * Specification for the activation of the fee distribution on the distributed token exchange.
+ *
+ * Once the feature with identifier 9 is active, fees from trading non-Omni pairs are distributed to Omni holders.
+ *
+ * During the grace period, the old rules are still in place.
+ *
+ * Note: this test is only successful with a clean state, and requires that the feature is initially disabled!
+ */
+@Stepwise
+class MetaDExFeesActivationSpec extends BaseActivationSpec {
+
+    @Shared Integer activationBlock = 999999
+    @Shared Address actorAddress
+
+    def beforeSpec() {
+        skipIfActivated(metaDExFeesFeatureId)
+        skipIfVersionOlderThan(1100000)
+    }
+
+    def setupSpec() {
+        actorAddress = createFundedAddress(startBTC, zeroAmount)
+    }
+
+    def "Feature identifier 9 can be used to schedule the activation of the fee distribution"() {
+        setup:
+        activationBlock = getBlockCount() + activationMinBlocks + 1 // one extra, for transaction confirmation
+
+        when:
+        def txid = omniSendActivation(actorAddress, metaDExFeesFeatureId, activationBlock, minClientVersion)
+        generateBlock()
+
+        then:
+        omniGetTransaction(txid).valid
+
+        when:
+        def activations = omniGetActivations()
+        def pendingActivations = activations.pendingactivations
+        def completedActivations = activations.completedactivations
+
+        then:
+        pendingActivations.any { it.featureid == metaDExFeesFeatureId }
+        !completedActivations.any { it.featureid == metaDExFeesFeatureId }
+
+        when:
+        def pendingFeature = pendingActivations.find { it.featureid == metaDExFeesFeatureId } as Map<String, Object>
+
+        then:
+        pendingFeature.featureid == metaDExFeesFeatureId
+        pendingFeature.activationblock == activationBlock
+        pendingFeature.minimumversion == minClientVersion
+    }
+
+    def "After the successful activation of the feature, the feature activation completed"() {
+        setup:
+        while (getBlockCount() < activationBlock) {
+            generateBlock()
+        }
+
+        when:
+        def activations = omniGetActivations()
+        def pendingActivations = activations.pendingactivations
+        def completedActivations = activations.completedactivations
+
+        then:
+        !pendingActivations.any { it.featureid == metaDExFeesFeatureId }
+        completedActivations.any { it.featureid == metaDExFeesFeatureId }
+
+        when:
+        def activatedFeature = completedActivations.find { it.featureid == metaDExFeesFeatureId } as Map<String, Object>
+
+        then:
+        activatedFeature.featureid == metaDExFeesFeatureId
+        activatedFeature.activationblock == activationBlock
+        activatedFeature.minimumversion == minClientVersion
+    }
+
+    def "Omni token holders are qualified to receive a share of trading fees"() {
+        setup:
+        def actorA = createFundedAddress(startBTC, 50.divisible)
+        def actorB = createFundedAddress(startBTC, 100.divisible)
+        def actorC = createFundedAddress(startBTC, 150.divisible)
+        def actorD = createFundedAddress(startBTC, 200.divisible)
+        def actorE = createFundedAddress(startBTC, 500.divisible)
+
+        when:
+        def feeShare = omniGetFeeShare(null, Ecosystem.TOMNI)
+        def feeShareA = feeShare.find { it.address == actorA.toString() } as Map<String, Object>
+        def feeShareB = feeShare.find { it.address == actorB.toString() } as Map<String, Object>
+        def feeShareC = feeShare.find { it.address == actorC.toString() } as Map<String, Object>
+        def feeShareD = feeShare.find { it.address == actorD.toString() } as Map<String, Object>
+        def feeShareE = feeShare.find { it.address == actorE.toString() } as Map<String, Object>
+
+        then:
+        feeShareA.feeshare == "5.0000%"
+        feeShareB.feeshare == "10.0000%"
+        feeShareC.feeshare == "15.0000%"
+        feeShareD.feeshare == "20.0000%"
+        feeShareE.feeshare == "50.0000%"
+    }
+
+}

--- a/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-rpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -588,4 +588,86 @@ public class OmniClient extends BitcoinExtendedClient {
         Map<String, List<Map<String, Object>>> activations = send("omni_getactivations");
         return activations;
     }
+
+    /**
+     * Obtains the current amount of fees cached (pending distribution).
+     *
+     * If a property ID is supplied the results will be filtered to show this property ID only. If no property ID is
+     * supplied the results will contain all properties that currently have fees cached pending distribution.
+     *
+     * @param propertyid the identifier of the property to filter results on
+     * @return A list of amounts of fees cached
+     * @since Omni Core 0.0.11
+     */
+    public List<Map<String, Object>> omniGetFeeCache(CurrencyID propertyid)
+            throws JsonRPCException, IOException {
+        List<Map<String, Object>> cache = send("omni_getfeecache", propertyid);
+        return cache;
+    }
+
+    /**
+     * Obtains the amount at which cached fees will be distributed.
+     *
+     * If a property ID is supplied the results will be filtered to show this property ID only.  If no property ID is
+     * supplied the results will contain all properties.
+     *
+     * @param propertyId the identifier of the property to filter results on
+     * @return A list of amounts of fees required to trigger distribution
+     * @since Omni Core 0.0.11
+     */
+    public List<Map<String, Object>> omniGetFeeTrigger(CurrencyID propertyId)
+            throws JsonRPCException, IOException {
+        List<Map<String, Object>> triggers = send("omni_getfeetrigger", propertyId);
+        return triggers;
+    }
+
+    /**
+     * Obtains the current percentage share of fees addresses would receive if a distribution were to occur.
+     *
+     * If an address is supplied the results will be filtered to show this address only. If no address is supplied the
+     * results will be filtered to show wallet addresses only.
+     *
+     * If an ecosystem is supplied the results will reflect the fee share for that ecosystem (main or test). If no
+     * ecosystem is supplied the results will reflect the main ecosystem.
+     *
+     * @param address   the address to filter results on
+     * @param ecosystem the ecosystem to obtain the current percentage fee share
+     * @return A list of percentages of fees the address(es) will receive based on the current state
+     * @since Omni Core 0.0.11
+     */
+    public List<Map<String, Object>> omniGetFeeShare(Address address, Ecosystem ecosystem)
+            throws JsonRPCException, IOException {
+        List<Map<String, Object>> shares = send("omni_getfeeshare", address, ecosystem);
+        return shares;
+    }
+
+    /**
+     * Obtains data for a past distribution of fees.
+     *
+     * A distribution ID must be supplied to identify the distribution to obtain data for.
+     *
+     * @param distributionId the identifier of the distribution to obtain data for
+     * @return Information about a fee distribution
+     * @since Omni Core 0.0.11
+     */
+    public Map<String, Object> omniGetFeeDistribution(Integer distributionId)
+            throws JsonRPCException, IOException {
+        Map<String, Object> info = send("omni_getfeedistribution", distributionId);
+        return info;
+    }
+
+    /**
+     * Obtains data for past distributions of fees for a property.
+     *
+     * A property ID must be supplied to retrieve past distributions for.
+     *
+     * @param propertyId the identifier of the property to retrieve past distributions for
+     * @return A list of fee distributions
+     * @since Omni Core 0.0.11
+     */
+    public List<Map<String, Object>> omniGetFeeDistributions(CurrencyID propertyId)
+            throws JsonRPCException, IOException {
+        List<Map<String, Object>> infos = send("omni_getfeedistributions", propertyId);
+        return infos;
+    }
 }


### PR DESCRIPTION
The following new RPCs were added:

- omni_getfeecache
- omni_getfeetrigger
- omni_getfeeshare
- omni_getfeedistribution
- omni_getfeedistributions

This also adds activation tests for the fee distirbution system.