### PR TITLE
Prepare OmniJ for Bitcoin Core 0.13 changes

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
@@ -4,6 +4,7 @@ import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
 import foundation.omni.OmniValue
 import foundation.omni.PropertyType
+import org.bitcoinj.core.Coin
 
 class SendToOwnersReorgSpec extends BaseReorgSpec {
 
@@ -164,6 +165,7 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         // secondOrphanedTx.confirmations == -1 TODO: activate after Omni Core adjustment
 
         when: "creating a third STO transaction"
+        requestBitcoin(actorAddress, Coin.CENT)  // maybe use startBTC instead
         def thirdTxid = omniSendSTO(actorAddress, tokenID, 50.divisible)
         generateBlock()
         def thirdTx = omniGetSTO(thirdTxid)

--- a/test-omni-integ-regtest.sh
+++ b/test-omni-integ-regtest.sh
@@ -27,7 +27,7 @@ ln -sf $MSCLOG $LOGDIR/mastercore.log
 rm -rf $DATADIR/regtest
 
 # Run omnicored in regtest mode
-$BTCD -regtest -datadir=$DATADIR -omnialertallowsender=any -omniactivationallowsender=any -paytxfee=0.0001 -minrelaytxfee=0.00001 > $LOGDIR/bitcoin.log &
+$BTCD -regtest -datadir=$DATADIR -omnialertallowsender=any -omniactivationallowsender=any -paytxfee=0.0001 -minrelaytxfee=0.00001 -limitancestorcount=750 -limitdescendantcount=750 > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!
 


### PR DESCRIPTION
The mempool chain limit is raised to 750 from the default of 25, because otherwise chains of unconfirmed transactions are limited to 25 transactions, which results in failures in the STO tests.

New BTC are explicitly requested in the STO reorg test, because apparently the sender has no more BTC after reorganizing the chain. It's unclear to me why this is needed in 0.13, but it resolves a test failure locally for me.