### PR TITLE
Use omniSendDExAccept instead of acceptDexOffer

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/dex/DexSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/dex/DexSpec.groovy
@@ -258,7 +258,7 @@ class DexSpec extends BaseRegTestSpec {
         generateBlock()
 
         and: "B accepts the offer"
-        def acceptTxid = acceptDexOffer(actorB, currencyOffered, offeredMSC, actorA)
+        def acceptTxid = omniSendDExAccept(actorB, actorA, currencyOffered, offeredMSC, false)
         generateBlock()
 
         then: "both transactions are valid"


### PR DESCRIPTION
When creating a DEx accept with `omniSendDExAccept`, the transaction fee may not be sufficient, because it uses the global client fee to create the accept transaction. Creating the transaction via Omni Core's RPC layer takes care of the fee handling.