### PR TITLE
Ignore unknown properties of BalanceEntry and PropertyBalanceEntry

### DIFF
--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/BalanceEntry.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/BalanceEntry.java
@@ -1,6 +1,7 @@
 package foundation.omni.rpc;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import foundation.omni.OmniValue;
 
@@ -12,6 +13,7 @@ import java.util.Iterator;
  * TODO: Move to omnij-core, remove Jackson annotations, write Serializer/Deserializer?
  * (move along with AddressBalanceEntry, PropertyBalanceEntry)
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BalanceEntry implements Iterable<OmniValue>  {
     protected final OmniValue balance;
     protected final OmniValue reserved;

--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/PropertyBalanceEntry.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/PropertyBalanceEntry.java
@@ -1,5 +1,6 @@
 package foundation.omni.rpc;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import foundation.omni.CurrencyID;
 import foundation.omni.OmniValue;
@@ -10,6 +11,7 @@ import java.math.BigDecimal;
 /**
  * Balance entry for an property/currency
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertyBalanceEntry extends BalanceEntry {
     private final CurrencyID propertyid;
 


### PR DESCRIPTION
Omni Core 0.3.1 adds two new fields: "frozen" to balance entries and "name" to the list of balance entries, when using omni_getallbalancesforaddress.

These fields are currently not yet available.