### PR TITLE
Ignore test for description of OMN and TOMN base tokens

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ListPropertiesSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/basic/ListPropertiesSpec.groovy
@@ -14,6 +14,7 @@ import foundation.omni.rpc.SmartPropertyListInfo
  */
 class ListPropertiesSpec extends BaseRegTestSpec {
 
+    @Ignore('OMNI, TOMNI changed to OMN, TOMN')
     def "Returns a property list with correct MSC and TMSC entries"() {
         when: "we get a list of properties"
         List<SmartPropertyListInfo> properties = omniListProperties()


### PR DESCRIPTION
The symbols and descriptions for the base tokens Omni and Test Omni changed, so the test is ignored, until the change is merged into a stable version.

This PR is combined with https://github.com/OmniLayer/omnicore/pull/908.