### PR TITLE
Use correct Omni Core log file of Travis CI regtests

### DIFF
--- a/test-omni-integ-regtest.sh
+++ b/test-omni-integ-regtest.sh
@@ -6,13 +6,13 @@ function cleanup {
 }
 trap cleanup EXIT
 
-BTCD=copied-artifacts/src/omnicored
+OMNICORED=copied-artifacts/src/omnicored
 DATADIR=$HOME/.bitcoin
 LOGDIR=logs
-MSCLOG=/tmp/mastercore.log
+OMNILOG=/tmp/omnicore.log
 
 # Assume omnicored built elsewhere and copied by Jenkins Copy Artifact plugin
-chmod +x $BTCD
+chmod +x $OMNICORED
 
 # Setup bitcoin conf and data dir
 mkdir -p $DATADIR
@@ -20,19 +20,19 @@ cp -n bitcoin.conf $DATADIR
 
 # setup logging
 mkdir -p $LOGDIR
-touch $MSCLOG
-ln -sf $MSCLOG $LOGDIR/mastercore.log
+touch $OMNILOG
+ln -sf $OMNILOG $LOGDIR/omnicore.log
 
 # Remove all regtest data
 rm -rf $DATADIR/regtest
 
 # Run omnicored in regtest mode
-$BTCD -regtest -datadir=$DATADIR -omnialertallowsender=any -omniactivationallowsender=any -paytxfee=0.0001 -minrelaytxfee=0.00001 -limitancestorcount=750 -limitdescendantcount=750 -rpcserialversion=0 -deprecatedrpc=generate > $LOGDIR/bitcoin.log &
+$OMNICORED -regtest -datadir=$DATADIR -omnialertallowsender=any -omniactivationallowsender=any -paytxfee=0.0001 -minrelaytxfee=0.00001 -limitancestorcount=750 -limitdescendantcount=750 -rpcserialversion=0 -deprecatedrpc=generate > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!
 
 # Give server some time to start
-#sleep 30
+# sleep 30
 
 # Run integration tests
 echo "Running Omni RPC integration tests in RegTest mode..."


### PR DESCRIPTION
The script still referred to the old mastercore.log log file, which was renamed to omnicore.log at some point.