### PR TITLE
SmartPropertyListInfo: JSON ignoreUnknown

### DIFF
--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/SmartPropertyListInfo.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/SmartPropertyListInfo.java
@@ -1,11 +1,13 @@
 package foundation.omni.rpc;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import foundation.omni.CurrencyID;
 
 /**
  * Result for a single property from {@code "omni_listproperties"}
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SmartPropertyListInfo {
     private final CurrencyID  propertyid;
     private final String      name;


### PR DESCRIPTION
Use Jackson annotation to ignore unknown properties.

This is a short-term solution to fix the tests which are currently failing for Omni Core in Git.

Obviously OmniJ will need an additional update to actually make the new fields available to clients. (We should also consider making “ignoreUnknown” JSON properties the default)

