### PR TITLE
Prototype Omni Bech32 (safe address) implementation

### DIFF
--- a/omnij-core/src/main/java/foundation/omni/address/OmniAddressMainNetParams.java
+++ b/omnij-core/src/main/java/foundation/omni/address/OmniAddressMainNetParams.java
@@ -10,8 +10,9 @@ import org.bitcoinj.params.MainNetParams;
 public class OmniAddressMainNetParams extends MainNetParams {
     public OmniAddressMainNetParams() {
         super();
-        addressHeader = 115;    // 'o'
-        p2shHeader = 58;        // 'Q'
+        addressHeader = 115;    // 'o' prefix for Base58 P2PKH (deprecated)
+        p2shHeader = 58;        // 'Q' prefix for Base58 P2SH (deprecated)
+        segwitAddressHrp = "o"; // Human-readable-part for Omni-Layer Bech32 addresses
     }
 
 

--- a/omnij-core/src/main/java/foundation/omni/address/OmniAddressRegTestParams.java
+++ b/omnij-core/src/main/java/foundation/omni/address/OmniAddressRegTestParams.java
@@ -1,0 +1,22 @@
+package foundation.omni.address;
+
+import org.bitcoinj.params.RegTestParams;
+
+/**
+ * EXPERIMENTAL Subclass of RegTestParams for generating Omni Addresses
+ */
+public class OmniAddressRegTestParams extends RegTestParams {
+    public OmniAddressRegTestParams() {
+        super();
+        segwitAddressHrp = "ort";   // Human-readable-part for Omni-Layer Bech32 addresses
+    }
+
+
+    private static OmniAddressRegTestParams instance;
+    public static synchronized OmniAddressRegTestParams get() {
+        if (instance == null) {
+            instance = new OmniAddressRegTestParams();
+        }
+        return instance;
+    }
+}

--- a/omnij-core/src/main/java/foundation/omni/address/OmniAddressTestNetParams.java
+++ b/omnij-core/src/main/java/foundation/omni/address/OmniAddressTestNetParams.java
@@ -1,0 +1,22 @@
+package foundation.omni.address;
+
+import org.bitcoinj.params.TestNet3Params;
+
+/**
+ * EXPERIMENTAL Subclass of TestNet3Params for generating Omni Addresses
+ */
+public class OmniAddressTestNetParams extends TestNet3Params {
+    public OmniAddressTestNetParams() {
+        super();
+        segwitAddressHrp = "to";    // Human-readable-part for Omni-Layer Bech32 addresses
+    }
+
+
+    private static OmniAddressTestNetParams instance;
+    public static synchronized OmniAddressTestNetParams get() {
+        if (instance == null) {
+            instance = new OmniAddressTestNetParams();
+        }
+        return instance;
+    }
+}

--- a/omnij-core/src/main/java/foundation/omni/address/OmniBase58LegacyAddressConverter.java
+++ b/omnij-core/src/main/java/foundation/omni/address/OmniBase58LegacyAddressConverter.java
@@ -7,7 +7,7 @@ import org.bitcoinj.params.MainNetParams;
 /**
  * EXPERIMENTAL 2-way Conversion between MAINNET Omni and BTC Addresses
  */
-public class OmniAddressConverter {
+public class OmniBase58LegacyAddressConverter {
     static final OmniAddressMainNetParams omniParams = OmniAddressMainNetParams.get();
     static final MainNetParams btcParams = MainNetParams.get();
 

--- a/omnij-core/src/main/java/foundation/omni/address/OmniSegwitAddressConverter.java
+++ b/omnij-core/src/main/java/foundation/omni/address/OmniSegwitAddressConverter.java
@@ -1,0 +1,101 @@
+package foundation.omni.address;
+
+import org.bitcoinj.core.Bech32;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SegwitAddress;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.Networks;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Convert between Bitcoin and Omni Bech32 Segwit addresses
+ * Adds Omni networks to bitcoinj's {@link Networks} registry
+ * Bitcoin: bc1xxxx
+ * Omni: om1xxxx
+ */
+public class OmniSegwitAddressConverter {
+    /**
+     * Default set of Omni Networks for Omni Address parsing
+     * (We don't include RegTest by default because RegTest and TestNet addresses use the same
+     * prefix in Base58 format)
+     */
+    public static final Set<NetworkParameters> defaultOmniNetworks =
+            unmodifiableSet(OmniAddressMainNetParams.get(), OmniAddressTestNetParams.get());
+
+    static {
+        // TODO: Maybe we don't want to modify bitcoinj's list of networks unless explicitly configured?
+        Networks.register(defaultOmniNetworks);
+    }
+
+    static SegwitAddress btcToOmni(SegwitAddress btcAddress) {
+        NetworkParameters omniParams = btcParamsToOmniParams(btcAddress.getParameters());
+        Bech32.Bech32Data btcBech32Data = Bech32.decode(btcAddress.toBech32());
+        String omniAddressString = Bech32.encode(omniParams.getSegwitAddressHrp(), btcBech32Data.data);
+        return SegwitAddress.fromBech32(omniParams, omniAddressString);
+    }
+
+    static SegwitAddress btcToOmni(String btcAddressString) {
+        SegwitAddress btcAddress = SegwitAddress.fromBech32(null, btcAddressString);
+        return btcToOmni(btcAddress);
+    }
+
+    static SegwitAddress btcToOmni(NetworkParameters btcParams, String btcAddressString) {
+        SegwitAddress btcAddress = SegwitAddress.fromBech32(btcParams, btcAddressString);
+        return btcToOmni(btcAddress);
+    }
+
+    static SegwitAddress omniToBtc(SegwitAddress omniAddress) {
+        NetworkParameters btcParams = omniParamsToBtcParams(omniAddress.getParameters());
+        Bech32.Bech32Data btcBech32Data = Bech32.decode(omniAddress.toBech32());
+        String btcAddressString = Bech32.encode(btcParams.getSegwitAddressHrp(), btcBech32Data.data);
+        return SegwitAddress.fromBech32(btcParams, btcAddressString);
+    }
+
+    static SegwitAddress omniToBtc(String omniAddressString) {
+        SegwitAddress btcAddress = SegwitAddress.fromBech32(null, omniAddressString);
+        return omniToBtc(btcAddress);
+    }
+
+    static SegwitAddress omniToBtc(NetworkParameters btcParams, String btcAddressString) {
+        SegwitAddress btcAddress = SegwitAddress.fromBech32(btcParams, btcAddressString);
+        return omniToBtc(btcAddress);
+    }
+
+    static private NetworkParameters btcParamsToOmniParams(NetworkParameters btcParams) {
+        switch (btcParams.getId()) {
+            case NetworkParameters.ID_MAINNET:
+                return OmniAddressMainNetParams.get();
+            case NetworkParameters.ID_TESTNET:
+                return OmniAddressTestNetParams.get();
+            case NetworkParameters.ID_REGTEST:
+                return OmniAddressRegTestParams.get();
+            default:
+                throw new IllegalArgumentException("Unspported network");
+        }
+    }
+
+    static private NetworkParameters omniParamsToBtcParams(NetworkParameters omniParams) {
+        switch (omniParams.getId()) {
+            case NetworkParameters.ID_MAINNET:
+                return MainNetParams.get();
+            case NetworkParameters.ID_TESTNET:
+                return TestNet3Params.get();
+            case NetworkParameters.ID_REGTEST:
+                return RegTestParams.get();
+            default:
+                throw new IllegalArgumentException("Unspported network");
+        }
+    }
+
+    // Create an unmodifiable set of NetworkParameters from an array/varargs
+    private static Set<NetworkParameters> unmodifiableSet(NetworkParameters... ts) {
+        return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ts)));
+    }
+
+}

--- a/omnij-core/src/test/groovy/foundation/omni/address/OmniBase58LegacyAddressConverterSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/address/OmniBase58LegacyAddressConverterSpec.groovy
@@ -11,7 +11,7 @@ import spock.lang.Unroll
 /**
  * Proof-of-concept test of conversion between Omni and BTC addresses
  */
-class OmniAddressConverterSpec extends Specification {
+class OmniBase58LegacyAddressConverterSpec extends Specification {
     static final omniParams = OmniAddressMainNetParams.get()
     static final btcParams = MainNetParams.get();
 
@@ -21,7 +21,7 @@ class OmniAddressConverterSpec extends Specification {
         def btcAddress = LegacyAddress.fromKey(btcParams, key)
 
         when: "we convert to Omni"
-        LegacyAddress omniAddress = OmniAddressConverter.btcToOmni(btcAddress)
+        LegacyAddress omniAddress = OmniBase58LegacyAddressConverter.btcToOmni(btcAddress)
 
         then: "it's a valid Omni address"
         omniAddress.parameters == omniParams
@@ -29,7 +29,7 @@ class OmniAddressConverterSpec extends Specification {
         omniAddress.toString().substring(0,1) == 'o'
 
         when: "we convert back to Bitcoin"
-        LegacyAddress backAgainBTCAddress = OmniAddressConverter.omniToBTC(omniAddress)
+        LegacyAddress backAgainBTCAddress = OmniBase58LegacyAddressConverter.omniToBTC(omniAddress)
 
         then: "it's the same, valid BTC address"
         backAgainBTCAddress == btcAddress
@@ -44,7 +44,7 @@ class OmniAddressConverterSpec extends Specification {
         def btcAddress = Address.fromString(btcParams, addressString)
 
         when: "we convert to Omni"
-        def omniAddress = OmniAddressConverter.btcToOmni(btcAddress)
+        def omniAddress = OmniBase58LegacyAddressConverter.btcToOmni(btcAddress)
 
         then: "it's a valid Omni address"
         omniAddress.parameters == omniParams
@@ -52,7 +52,7 @@ class OmniAddressConverterSpec extends Specification {
         omniAddress.toString().substring(0,1) == 'o'
 
         when: "we convert back to Bitcoin"
-        def backAgainBTCAddress = OmniAddressConverter.omniToBTC(omniAddress)
+        def backAgainBTCAddress = OmniBase58LegacyAddressConverter.omniToBTC(omniAddress)
 
         then: "it's the same, valid BTC address"
         backAgainBTCAddress == btcAddress
@@ -70,7 +70,7 @@ class OmniAddressConverterSpec extends Specification {
         def omniAddress = Address.fromString(omniParams, addressString)
 
         when: "we convert to BTC"
-        def btcAddress = OmniAddressConverter.omniToBTC(omniAddress)
+        def btcAddress = OmniBase58LegacyAddressConverter.omniToBTC(omniAddress)
 
         then: "it's a valid BTC address"
         btcAddress.parameters == btcParams
@@ -78,7 +78,7 @@ class OmniAddressConverterSpec extends Specification {
         btcAddress.toString().substring(0,1) == '1'
 
         when: "we convert back to Omni"
-        def backAgainOmniAddress = OmniAddressConverter.btcToOmni(btcAddress)
+        def backAgainOmniAddress = OmniBase58LegacyAddressConverter.btcToOmni(btcAddress)
 
         then: "it's the same, valid Omni address"
         backAgainOmniAddress == omniAddress

--- a/omnij-core/src/test/groovy/foundation/omni/address/OmniSegwitAddressConverterSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/address/OmniSegwitAddressConverterSpec.groovy
@@ -1,0 +1,121 @@
+package foundation.omni.address
+
+import org.bitcoinj.core.Address
+import org.bitcoinj.core.ECKey
+import org.bitcoinj.core.NetworkParameters
+import org.bitcoinj.core.SegwitAddress
+import org.bitcoinj.params.MainNetParams
+import org.bitcoinj.params.Networks
+import org.bitcoinj.script.Script
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Test conversion between BTC and Omni Segwit/Bech32 addresses
+ */
+class OmniSegwitAddressConverterSpec extends Specification {
+    static final omniParams = OmniAddressMainNetParams.get()
+    static final btcParams = MainNetParams.get();
+    static final bitFinexColdWalletAddress = "bc1qgdjqv0av3q56jvd82tkdjpy7gdp9ut8tlqmgrpmv24sq90ecnvqqjwvw97"
+
+
+    @Unroll
+    def "A list of known address are convertible"(String btc, String omni) {
+        expect: "Conversion works in both directions"
+        omni == OmniSegwitAddressConverter.btcToOmni(fromBech32(btc)).toString()
+        btc == OmniSegwitAddressConverter.omniToBtc(fromBech32(omni)).toString()
+
+        where:
+        btc                                                                 | omni
+        'bc1qgdjqv0av3q56jvd82tkdjpy7gdp9ut8tlqmgrpmv24sq90ecnvqqjwvw97'    | 'o1qgdjqv0av3q56jvd82tkdjpy7gdp9ut8tlqmgrpmv24sq90ecnvqqu9f4ew'
+        'bc1q5shngj24323nsrmxv99st02na6srekfctt30ch'                        | 'o1q5shngj24323nsrmxv99st02na6srekfc6rupyk'
+        'bc1q2raxkmk55p000ggfa8euzs9fzq7p4cx4twycx7'                        | 'o1q2raxkmk55p000ggfa8euzs9fzq7p4cx46xfk6l'
+        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'                        | 'o1qw508d6qejxtdg4y5r3zarvary0c5xw7ka0ylh5'
+        'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'                        | 'to1qw508d6qejxtdg4y5r3zarvary0c5xw7kjw58mu'
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3'    | 'o1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qknvqsp'
+        'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7'    | 'to1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qz3y9y6'
+
+    }
+
+    def "2 way conversion works for a random address"() {
+        given: "a random-generated Elliptic Curve private key and associated Bitcoin address"
+        def key = new ECKey()
+        def btcAddress = SegwitAddress.fromKey(btcParams, key)
+
+        when: "we convert to Omni"
+        SegwitAddress omniAddress = OmniSegwitAddressConverter.btcToOmni(btcAddress)
+
+        then: "it's a valid Omni address"
+        omniAddress.parameters == omniParams
+        omniAddress.getOutputScriptType() == Script.ScriptType.P2WPKH
+        omniAddress.toString().substring(0,2) == 'o1'
+
+        when: "we convert back to Bitcoin"
+        SegwitAddress backAgainBTCAddress = OmniSegwitAddressConverter.omniToBtc(omniAddress)
+
+        then: "it's the same, valid BTC address"
+        backAgainBTCAddress == btcAddress
+        backAgainBTCAddress.parameters == btcParams
+        backAgainBTCAddress.getOutputScriptType() == Script.ScriptType.P2WPKH
+        backAgainBTCAddress.toString().substring(0,3) == 'bc1'
+    }
+
+    @Unroll
+    def "2 way conversion works for Bitcoin address #addressString"(String addressString) {
+        given: "a bitcoin address"
+        def btcAddress = Address.fromString(btcParams, addressString)
+
+        when: "we convert to Omni"
+        def omniAddress = OmniSegwitAddressConverter.btcToOmni(btcAddress)
+
+        then: "it's a valid Omni address"
+        omniAddress.parameters == omniParams
+        omniAddress.getOutputScriptType() == Script.ScriptType.P2WPKH || omniAddress.getOutputScriptType() == Script.ScriptType.P2WSH
+        omniAddress.toString().substring(0,2) == 'o1'
+
+        when: "we convert back to Bitcoin"
+        def backAgainBTCAddress = OmniSegwitAddressConverter.omniToBtc(omniAddress)
+
+        then: "it's the same, valid BTC address"
+        backAgainBTCAddress == btcAddress
+        backAgainBTCAddress.parameters == btcParams
+        backAgainBTCAddress.getOutputScriptType() == Script.ScriptType.P2WPKH || backAgainBTCAddress.getOutputScriptType() == Script.ScriptType.P2WSH
+
+        where:
+        addressString << [bitFinexColdWalletAddress, "bc1q5shngj24323nsrmxv99st02na6srekfctt30ch", "bc1q2raxkmk55p000ggfa8euzs9fzq7p4cx4twycx7"]
+    }
+
+    @Unroll
+    def "2 way conversion works for Omni address #addressString"(String addressString) {
+        given: "an Omni address"
+        def omniAddress = Address.fromString(omniParams, addressString)
+
+        when: "we convert to BTC"
+        def btcAddress = OmniSegwitAddressConverter.omniToBtc(omniAddress)
+
+        then: "it's a valid BTC address"
+        btcAddress.parameters == btcParams
+        btcAddress.getOutputScriptType() == Script.ScriptType.P2WPKH || btcAddress.getOutputScriptType() == Script.ScriptType.P2WSH
+        btcAddress.toString().substring(0,3) == 'bc1'
+
+        when: "we convert back to Omni"
+        def backAgainOmniAddress = OmniSegwitAddressConverter.btcToOmni(btcAddress)
+
+        then: "it's the same, valid Omni address"
+        backAgainOmniAddress == omniAddress
+        backAgainOmniAddress.parameters == omniParams
+        backAgainOmniAddress.getOutputScriptType() == Script.ScriptType.P2WPKH || backAgainOmniAddress.getOutputScriptType() == Script.ScriptType.P2WSH
+
+        where:
+        addressString << ["o1qgdjqv0av3q56jvd82tkdjpy7gdp9ut8tlqmgrpmv24sq90ecnvqqu9f4ew", "o1q5shngj24323nsrmxv99st02na6srekfc6rupyk"]
+    }
+
+    static SegwitAddress fromBech32(String addressString) {
+        SegwitAddress.fromBech32(null, addressString)
+    }
+
+    void setupSpec() {
+        // Registration is not necessary here as long as OmniSegwitAddressConverter is calling bitcoinj's Networks.register
+        // Networks.register([OmniAddressMainNetParams.get(), OmniAddressTestNetParams.get()])
+    }
+}


### PR DESCRIPTION
* Rename and prepare to deprecate experimental Omni Base58 address support
* Add `o` HRP (human readable part) to OmniAddressMainNetParams
* Create OmniAddressTestNetParams with `to` HRP
* Create OmniAddressRegTestParams with `ort` HRP
* Add OMniSegwitAddressConverter class (and test Specification)