### PR TITLE
By default ignore unknown JSON props in 3 places:

### DIFF
--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -1,5 +1,6 @@
 package foundation.omni.rpc;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.msgilligan.bitcoinj.rpc.BitcoinExtendedClient;
 import foundation.omni.json.pojo.OmniPropertyInfo;
@@ -48,6 +49,7 @@ public class OmniClient extends BitcoinExtendedClient {
 
     public OmniClient(NetworkParameters netParams, URI server, String rpcuser, String rpcpassword) throws IOException {
         super(netParams, server, rpcuser, rpcpassword);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.registerModule(new OmniClientModule(getNetParams()));
         // Create a DecimalFormat that fits our requirements
         DecimalFormatSymbols symbols = new DecimalFormatSymbols();

--- a/omnij-rest-client-mjdk/src/main/java/foundation/omni/rest/omniwallet/mjdk/OmniwalletModernJDKClient.java
+++ b/omnij-rest-client-mjdk/src/main/java/foundation/omni/rest/omniwallet/mjdk/OmniwalletModernJDKClient.java
@@ -2,6 +2,7 @@ package foundation.omni.rest.omniwallet.mjdk;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import foundation.omni.CurrencyID;
 import foundation.omni.netapi.omniwallet.OmniwalletAbstractClient;
@@ -42,6 +43,7 @@ public class OmniwalletModernJDKClient extends OmniwalletAbstractClient {
         super(baseURI, true, false);
         this.client = HttpClient.newHttpClient();
         objectMapper = new UncheckedObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.registerModule(new OmniwalletClientModule(netParams));
     }
     

--- a/omnij-rest-client/src/main/java/foundation/omni/rest/omniwallet/OmniwalletClient.java
+++ b/omnij-rest-client/src/main/java/foundation/omni/rest/omniwallet/OmniwalletClient.java
@@ -1,6 +1,7 @@
 package foundation.omni.rest.omniwallet;
 
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import foundation.omni.netapi.omniwallet.OmniwalletAbstractClient;
 import foundation.omni.netapi.omniwallet.json.OmniwalletPropertiesListResponse;
@@ -86,6 +87,7 @@ public class OmniwalletClient extends OmniwalletAbstractClient {
     public OmniwalletClient(URI baseURI, boolean debug, boolean strictMode,  OkHttpClient client, Executor executor) {
         super(baseURI, debug, strictMode);
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.registerModule(new OmniwalletClientModule(netParams));
 
         Retrofit restAdapter = new Retrofit.Builder()


### PR DESCRIPTION
* OmniClient (JSON-RPC)
* OmniwalletClient (Retrofit)
* OmniwalledModernJDKClient (java.net.http JDK 11)

(We can remove the “ignore unknown” annotations later.)