### PR TITLE
Enable useJUnitPlaform(), Spock 2.0 fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ subprojects {
     }
 
     test {
+        useJUnitPlatform()
         testLogging.showStandardStreams = true
     }
 

--- a/omnij-core/src/test/groovy/foundation/omni/EcosystemSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/EcosystemSpec.groovy
@@ -8,7 +8,7 @@ import spock.lang.Unroll
  */
 class EcosystemSpec extends Specification {
 
-    def "Real MSC Ecosystem has value 1"() {
+    def "Real Omni Ecosystem has value 1"() {
         when: "we create real ecosystem"
         Ecosystem ecosystem = Ecosystem.OMNI
 
@@ -18,7 +18,7 @@ class EcosystemSpec extends Specification {
         ecosystem.getValue() == (short) 1
     }
 
-    def "Test MSC Ecosystem has value 2"() {
+    def "Test Omni Ecosystem has value 2"() {
         when: "we create test ecosystem"
         Ecosystem ecosystem = Ecosystem.TOMNI
 
@@ -29,19 +29,19 @@ class EcosystemSpec extends Specification {
     }
 
     @Unroll
-    def "constructor is strongly typed and won't allow all Number subclasses (#id)"() {
+    def "constructor is strongly typed and won't allow all Number subclasses (#id)"(id) {
         when: "we try to create an ecosystem using an invalid numeric type"
         Ecosystem ecosystem = new Ecosystem(id)
 
         then: "exception is thrown"
-        groovy.lang.GroovyRuntimeException e = thrown()
+        GroovyRuntimeException e = thrown()
 
         where:
         id << [1F, 1.1F, 1.0D, 1.1D, 1.0, 1.1, 1.0G, 1.1G]
     }
 
     @Unroll
-    def "An Ecosystem can be represented as String (#id -> #ecosystemAsString)"() {
+    def "An Ecosystem can be represented as String (#ecosystem -> #ecosystemAsString)"(Ecosystem ecosystem, String ecosystemAsString) {
         expect:
         ecosystem.toString() == ecosystemAsString
 

--- a/omnij-rpc/build.gradle
+++ b/omnij-rpc/build.gradle
@@ -48,6 +48,7 @@ sourceSets {
  */
 class IntegrationTest extends Test {
     public IntegrationTest() {
+        useJUnitPlatform()
         testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
         classpath = project.sourceSets.integrationTest.runtimeClasspath
         outputs.upToDateWhen { false }

--- a/omnij-rpc/src/test/groovy/foundation/omni/json/conversion/AddressBalanceEntriesDeserializerSpec.groovy
+++ b/omnij-rpc/src/test/groovy/foundation/omni/json/conversion/AddressBalanceEntriesDeserializerSpec.groovy
@@ -21,7 +21,7 @@ class AddressBalanceEntriesDeserializerSpec extends BaseOmniClientMapperSpec {
     static final LegacyAddress moneyMan = LegacyAddress.fromBase58(null, "moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP")
 
     @Unroll
-    def "fragment #fragment scans to #expectedResult"(String fragment, BalanceEntry expectedEntry) {
+    def "fragment #fragment scans to #expectedEntry"(String fragment, BalanceEntry expectedEntry) {
         when:
         AddressBalanceEntries expectedResult = new AddressBalanceEntries();
         if (expectedEntry != null) {


### PR DESCRIPTION
Commit 2c22dbcb9d3c1a91ca96d31129002396fd8e9ef3 effectively turned off all unit tests while still allowing the build to complete successfully.

This commit re-enables the unit-tests, but because we've upgrade to Spock 2.0 and JUnit 5 -- some of the tests are now failing.

My recommendation is that we merge this PR to `master` **and** merge another PR that temporarily `@Ignore`s the failing tests. We can then create a branch without the `@Ignore`d tests and resolve the remaining issues on that branch.
