### PR TITLE
Remove deprecated createFundedAddress() overloads

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/BaseReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/BaseReorgSpec.groovy
@@ -1,5 +1,7 @@
 package foundation.omni.test.rpc.reorgs
 
+import foundation.omni.OmniDivisibleValue
+import org.bitcoinj.core.Coin
 import org.consensusj.jsonrpc.JsonRpcException
 import foundation.omni.BaseRegTestSpec
 import org.bitcoinj.core.Sha256Hash
@@ -7,8 +9,8 @@ import org.junit.internal.AssumptionViolatedException
 
 abstract class BaseReorgSpec extends BaseRegTestSpec {
 
-    static protected BigDecimal startBTC = 0.1
-    static protected BigDecimal startMSC = 0.2
+    static protected Coin startBTC = 0.1.btc
+    static protected OmniDivisibleValue startOMNI = 0.2.divisible
 
     def setupSpec() {
         try {

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/PropertyCreationReorgSpec.groovy
@@ -60,7 +60,7 @@ class PropertyCreationReorgSpec extends BaseReorgSpec {
     @Unroll
     def "In #ecosystem, after invalidating the creation of #value tokens, the transaction and the tokens are invalid"()
     {
-        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def actorAddress = createFundedAddress(startBTC, startOMNI)
 
         when: "broadcasting and confirming a property creation transaction"
         def txid = createProperty(actorAddress, ecosystem, value)

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
@@ -12,8 +12,8 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
     {
         given:
         def sendAmount = 0.1.divisible
-        def senderAddress = createFundedAddress(startBTC, startMSC)
-        def dummyOwnerAddress = createFundedAddress(startBTC, startMSC)
+        def senderAddress = createFundedAddress(startBTC, startOMNI)
+        def dummyOwnerAddress = createFundedAddress(startBTC, startOMNI)
 
         when: "broadcasting and confirming a send to owners transaction"
         def txid = omniSendSTO(senderAddress, CurrencyID.TOMNI, sendAmount)
@@ -34,7 +34,7 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
     def "After invalidating a send to owners transaction, the original balances are restored"()
     {
         given:
-        def senderAddress = createFundedAddress(startBTC, startMSC)
+        def senderAddress = createFundedAddress(startBTC, startOMNI)
         def dummyOwnerA = newAddress
         def dummyOwnerB = newAddress
         def dummyOwnerC = newAddress
@@ -108,7 +108,7 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
 
     def "Historical STO transactions are not affected by reorganizations"() {
         when:
-        def actorAddress = createFundedAddress(startBTC, startMSC)
+        def actorAddress = createFundedAddress(startBTC, startOMNI)
         def tokenID = fundNewProperty(actorAddress, 100.divisible, Ecosystem.OMNI)
         def ownerA = newAddress
         def ownerB = newAddress
@@ -117,7 +117,7 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         generate()
 
         then:
-        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startMSC
+        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startOMNI
         omniGetBalance(actorAddress, tokenID).balance == 100.0 - 20.0
         omniGetBalance(ownerA, tokenID).balance == 10.0
         omniGetBalance(ownerB, tokenID).balance == 10.0
@@ -148,7 +148,7 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
 
         and: "the actor was charged"
         omniGetBalance(actorAddress, tokenID).balance == 100.0 - 20.0 - 30.0
-        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startMSC - (2 * 0.00000001)
+        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startOMNI - (2 * 0.00000001)
 
         when: "sending a second STO transaction"
         def secondTxid = omniSendSTO(actorAddress, tokenID, 30.divisible)
@@ -195,6 +195,6 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         omniGetBalance(actorAddress, tokenID).balance == 100.0 - 20.0 - 30.0 - 50.0
         omniGetBalance(ownerA, tokenID).balance == 10.0 + 15.0 + 25.0 // initial + first STO + third STO
         omniGetBalance(ownerB, tokenID).balance == 10.0 + 15.0 + 25.0
-        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startMSC - (4 * 0.00000001) // fee for each owner
+        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startOMNI - (4 * 0.00000001) // fee for each owner
     }
 }

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SimpleSendReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SimpleSendReorgSpec.groovy
@@ -10,7 +10,7 @@ class SimpleSendReorgSpec extends BaseReorgSpec {
     {
         given:
         def receiverAddress = newAddress
-        def senderAddress = createFundedAddress(startBTC, startMSC)
+        def senderAddress = createFundedAddress(startBTC, startOMNI)
         def blockCountBeforeSend = getBlockCount()
 
         when: "broadcasting and confirming a simple send"
@@ -40,7 +40,7 @@ class SimpleSendReorgSpec extends BaseReorgSpec {
         def blockHashBeforeFunding = generateAndGetBlockHash()
 
         def receiverAddress = newAddress
-        def senderAddress = createFundedAddress(startBTC, startMSC)
+        def senderAddress = createFundedAddress(startBTC, startOMNI)
 
         def balanceBeforeSendActor = omniGetBalance(senderAddress, CurrencyID.OMNI)
         def balanceBeforeSendReceiver = omniGetBalance(receiverAddress, CurrencyID.OMNI)

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
@@ -3,8 +3,10 @@ package foundation.omni.test.rpc.smartproperty
 import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
+import foundation.omni.OmniDivisibleValue
 import foundation.omni.PropertyType
 import org.bitcoinj.core.Address
+import org.bitcoinj.core.Coin
 import org.bitcoinj.core.Sha256Hash
 import spock.lang.Ignore
 import spock.lang.Shared
@@ -13,8 +15,8 @@ import spock.lang.Stepwise
 @Stepwise
 class ManagedPropertySpec extends BaseRegTestSpec {
 
-    final static BigDecimal startBTC = 0.1
-    final static BigDecimal zeroAmount = 0.0
+    final static Coin startBTC = 0.1.btc
+    final static OmniDivisibleValue zeroAmount = 0.0.divisible
 
     @Shared Address actorAddress
     @Shared Address otherAddress

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/SmartPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/SmartPropertySpec.groovy
@@ -6,6 +6,7 @@ import org.bitcoinj.core.Address
 import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
+import org.bitcoinj.core.Coin
 import spock.lang.Shared
 
 /*
@@ -16,8 +17,8 @@ import spock.lang.Shared
 
 class SmartPropertySpec extends BaseRegTestSpec {
 
-    final static BigDecimal startBTC = 1.0
-    final static BigDecimal startMSC = 50.0
+    final static Coin startBTC = 1.0.btc
+    final static OmniDivisibleValue startMSC = 50.0.divisible
 
     @Shared
     Address fundedAddress

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToManyOwnersSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToManyOwnersSpec.groovy
@@ -38,7 +38,7 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         def actorMSC = maxN * stoFeePerAddress
 
         // Create actor
-        def actorAddress = createFundedAddress(1.0, actorMSC)
+        def actorAddress = createFundedAddress(1.0.btc, actorMSC.divisible)
 
         // Create property
         println String.format("Creating a new %s with %s units ...", propertyType.toString(), fundingSPT.toPlainString())
@@ -137,7 +137,7 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         def actorMSC = maxN * stoFeePerAddress
 
         // Create actor
-        def actorAddress = createFundedAddress(1.0, actorMSC, false)
+        def actorAddress = createFundedAddress(1.0.btc, actorMSC.divisible, false)
 
         // Create property
         def currencySPT = fundNewProperty(actorAddress, fundingSPT, propertyType, Ecosystem.OMNI)

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersSpec.groovy
@@ -59,7 +59,7 @@ class SendToOwnersSpec extends BaseRegTestSpec {
 
     def "STO fails when amount sent is zero"() {
         setup:
-        def fundedAddress = createFundedAddress(10.0, 100.0)
+        def fundedAddress = createFundedAddress(10.0.btc, 100.0.divisible)
         def currencyID = TOMNI
         def startBalances = consensusTool.getConsensusSnapshot(currencyID)
 

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
@@ -12,6 +12,7 @@ import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
 import foundation.omni.PropertyType
 import org.junit.AssumptionViolatedException
+
 import spock.lang.Shared
 import spock.lang.Unroll
 import spock.util.mop.Use

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -71,16 +71,6 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate, RawTxDe
         return txid
     }
 
-    @Deprecated
-    Address createFundedAddress(BigDecimal requestedBTC, BigDecimal requestedMSC) {
-        return createFundedAddress(btcToCoin(requestedBTC), OmniDivisibleValue.of(requestedMSC), true)
-    }
-
-    @Deprecated
-    Address createFundedAddress(BigDecimal requestedBTC, BigDecimal requestedMSC, Boolean confirmTransactions) {
-        return createFundedAddress(btcToCoin(requestedBTC), OmniDivisibleValue.of(requestedMSC), confirmTransactions)
-    }
-
     Address createFundedAddress(Coin requestedBTC, OmniValue requestedMSC) {
         return createFundedAddress(requestedBTC, requestedMSC, true)
     }


### PR DESCRIPTION
and use Coin and OmniDivisible types in callers to use the correct
createFundedAddress() method.

Also rename MSC to OMNI in a few places.