### PR TITLE
Change tests to use new default RegTest RPC port

### DIFF
--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -6,3 +6,6 @@ txindex=1
 debug=1
 logtimestamps=1
 omniseedblockfilter=0
+
+[regtest]
+rpcport=18443

--- a/omnij-rpc/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
@@ -26,11 +26,11 @@ abstract class BaseRegTestSpec extends Specification implements OmniTestClientDe
 
     {
         // If Bitcoin Core 0.16.0 or greater, rpc port for RegTest has changed. ConsensusJ 0.5.0
-        // reflects this change, but Travis tests are still testing an old Omni Core.
+        // reflects this change, but some tests are still testing an old Omni Core.
         // Previously Bitcoin Core (and Omni Core) used the same port as TESTNET for REGTEST
         // This recentBitcoinCore hack allows those tests to pass until we update `travis.yml`
         // and any other test configuration/infrastructure, etc.
-        boolean recentBitcoinCore = false;
+        boolean recentBitcoinCore = true;
         URI regTestRpcUri = recentBitcoinCore ? RpcURI.defaultRegTestURI : RpcURI.defaultTestNetURI
         client = new OmniTestClient(RegTestParams.get(), regTestRpcUri, rpcTestUser, rpcTestPassword)
         fundingSource = new RegTestFundingSource(client)

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/RegTestContext.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/RegTestContext.groovy
@@ -11,11 +11,11 @@ import org.bitcoinj.params.RegTestParams
 class RegTestContext {
     static setup(String user, String pass) {
         // If Bitcoin Core 0.16.0 or greater, rpc port for RegTest has changed. ConsensusJ 0.5.0
-        // reflects this change, but Travis tests are still testing an old Omni Core.
+        // reflects this change, but some tests are still testing an old Omni Core.
         // Previously Bitcoin Core (and Omni Core) used the same port as TESTNET for REGTEST
         // This recentBitcoinCore hack allows those tests to pass until we update `travis.yml`
         // and any other test configuration/infrastructure, etc.
-        def recentBitcoinCore = false;
+        def recentBitcoinCore = true;
         URI regTestRpcUri = recentBitcoinCore ? RpcURI.defaultRegTestURI : RpcURI.defaultTestNetURI
         def client = new OmniTestClient(RegTestParams.get(), regTestRpcUri, user, pass)
         def env = new RegTestEnvironment(client)


### PR DESCRIPTION
Keeping this ready for when Omni Core changes its default port for RegTest RPCs.