### PR TITLE
Add config for Graal native-image build of CLI tool

### DIFF
--- a/omnij-cli/build.gradle
+++ b/omnij-cli/build.gradle
@@ -48,6 +48,25 @@ jar {
     }
 }
 
+// Compile a native image using GraalVM's native-image tool
+// Graal must be installed at $GRAAL_HOME
+task nativeImage(type:Exec, dependsOn: jar) {
+    workingDir = projectDir
+    executable = "${System.env.GRAAL_HOME}/bin/native-image"
+    args = [ '--verbose',
+             '--no-fallback',
+             '-cp', "${-> configurations.runtimeClasspath.asPath}", // Lazy configuration resolution
+             '-jar', jar.archiveFile.get(),
+             '-H:Path=build',
+             '-H:Name=omnij-consensus-tool',
+             '--initialize-at-build-time=com.fasterxml.jackson.annotation.JsonProperty$Access',
+             '-H:IncludeResources=logging.properties',
+             '-H:ReflectionConfigurationFiles=graal-reflection-config.json',
+             '-H:EnableURLProtocols=http,https',
+             '-H:+ReportUnsupportedElementsAtRuntime'
+    ]
+}
+
 // Test Structure
 sourceSets {
     integrationTest {

--- a/omnij-cli/graal-reflection-config.json
+++ b/omnij-cli/graal-reflection-config.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name" : "java.lang.Object",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true
+  },
+  {
+    "name" : "java.util.List",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true
+  },
+  {
+    "name" : "org.consensusj.jsonrpc.JsonRpcRequest",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true
+  },
+  {
+    "name" : "org.consensusj.jsonrpc.JsonRpcResponse",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "org.consensusj.jsonrpc.JsonRpcError",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "org.consensusj.jsonrpc.internal.NumberStringSerializer",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "foundation.omni.rpc.AddressBalanceEntry",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "foundation.omni.netapi.omniwallet.json.RevisionInfo",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "foundation.omni.netapi.omniwallet.json.AddressVerifyInfo",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "foundation.omni.netapi.omniwallet.json.OmniwalletPropertiesListResponse",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true
+  },
+  {
+    "name" : "foundation.omni.netapi.omniwallet.json.OmniwalletPropertyInfo",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredClasses" : true
+  },
+  {
+    "name" : "foundation.omni.netapi.omniwallet.json.OmniwalletPropertyInfo$Issuance",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredClasses" : true
+  },
+  {
+    "name" : "foundation.omni.rpc.SmartPropertyListInfo",
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true,
+    "allPublicConstructors" : true,
+    "fields" : [
+      { "name" : "subcategory", "allowWrite" : true }
+    ]
+  }
+]


### PR DESCRIPTION
Add Gradle and reflection config JSON file for building a natively compiled `omnij-consensus-tool`.

This is a DRAFT PR because we should probably wait until `msgilligan-refactor-to-async`... is merged into `master` before merging this one.
