### PR TITLE
Add Github Actions and enable Gradle build scans

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -1,0 +1,39 @@
+name: GraalVM Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        graalvm: [ '20.1.0.java11' ]
+      fail-fast: false
+    name: ${{ matrix.os }} JDK ${{ matrix.graalvm }}
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v1
+    - name: Set up GraalVM
+      uses: DeLaGuardo/setup-graalvm@3
+      with:
+        graalvm-version: '20.1.0.java11'
+    - name: Set GRAAL_HOME
+      run: echo '::set-env name=GRAAL_HOME::${{env.JAVA_HOME}}'
+    - name: Install native-image plugin
+      run: gu install native-image
+    - name: Verify Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Build with Gradle
+      run: ./gradlew :omnij-cli:nativeImage --scan --info --stacktrace
+    - name: Upload omnij-consensus-tool as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: omnij-cosensus-tool-${{ matrix.os }}
+        path: omnij-cli/build/omnij-consensus-tool

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,30 @@
+name: Gradle Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        java: [ '11', '14' ]
+      fail-fast: false
+    name: ${{ matrix.os }} JDK ${{ matrix.java }}
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Verify Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Build with Gradle
+      run: ./gradlew buildCI --scan --info --stacktrace

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -1,0 +1,39 @@
+name: Omni Core RegTest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [ '11', '14' ]
+      fail-fast: false
+    name: ${{ matrix.os }} JDK ${{ matrix.java }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Download Omni Core
+      run: ./test-download-omnicore-ubuntu.sh
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Verify Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Run RegTests
+      run: ./test-omni-integ-regtest.sh
+    - name: Upload RegTest results as artifact
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: regtest-omnij-jdk${{ matrix.java }}-${{ matrix.os }}-reports
+        path: |
+          omnij-cli/build/reports/tests/regTest
+          omnij-rpc/build/reports/tests/regTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ os: linux
 dist: xenial
 language: java
 
-env:
-  global:
-  - OMNICORE_HOST=https://bintray.com/artifact/download/omni/OmniBinaries
-  - OMNICORE_RELEASE=omnicore-0.8.2
-  - OMNICORE_FILE=$OMNICORE_RELEASE-x86_64-linux-gnu.tar.gz
-  - OMNICORE_HASH=13fad4537f98ab5356454436df6a808995c2c462563d4256a191fea0f10458e9
-
 cache:
   directories:
   - $HOME/.gradle/caches
@@ -17,14 +10,10 @@ cache:
 install:
   - sudo apt-get update
   - sudo apt-get install graphviz
-  - wget "$OMNICORE_HOST/$OMNICORE_FILE"
-  - echo "$OMNICORE_HASH  $OMNICORE_FILE" | shasum --algorithm 256 --check
-  - mkdir -p copied-artifacts/src/
-  - tar zxvf $OMNICORE_FILE -C /tmp
-  - mv /tmp/$OMNICORE_RELEASE/bin/omnicored copied-artifacts/src/
+  - ./test-download-omnicore-ubuntu.sh
 
 script:
-  - ./gradlew buildCI --stacktrace --info
+  - ./gradlew buildCI --scan --stacktrace --info
   - ./test-omni-integ-regtest.sh
 
 jdk:

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ This is pre-release software and APIs may change without notice.
 
 == OmniJ
 
-image:https://travis-ci.org/OmniLayer/OmniJ.svg?branch=master["Build Status", link="https://travis-ci.org/OmniLayer/OmniJ"] image:https://api.bintray.com/packages/omni/maven/omnij/images/download.svg[link="https://bintray.com/omni/maven/omnij/_latestVersion"]
+image:https://github.com/OmniLayer/OmniJ/workflows/Gradle%20Build/badge.svg["Build Status", link="https://github.com/OmniLayer/OmniJ/actions?query=workflow%3A%22Gradle+Build%22"] image:https://github.com/OmniLayer/OmniJ/workflows/Omni%20Core%20RegTest/badge.svg["Build Status", link="https://github.com/OmniLayer/OmniJ/actions?query=workflow%3A%22Omni+Core+RegTest%22"] image:https://github.com/OmniLayer/OmniJ/workflows/GraalVM%20Build/badge.svg["Build Status", link="https://github.com/OmniLayer/OmniJ/actions?query=workflow%3A%22GraalVM+Build%22"] image:https://travis-ci.org/OmniLayer/OmniJ.svg?branch=master["Build Status", link="https://travis-ci.org/OmniLayer/OmniJ"] image:https://api.bintray.com/packages/omni/maven/omnij/images/download.svg[link="https://bintray.com/omni/maven/omnij/_latestVersion"]
 
 A Java/JVM implementation of the http://www.omnilayer.org[Omni Layer], an open-source, fully decentralized asset creation platform built on the Bitcoin blockchain.
 
@@ -241,6 +241,13 @@ These sample Spock "feature tests" are from the file https://github.com/OmniLaye
 The command-line consensus tool, `omnij-consensus-tool` can be built into a native, self-contained, executable using https://www.graalvm.org[GraalVM]. You'll need a Java 11 (or later) version of GraalVM, we currently recommend version 20.1.0 (java11).
 
 === Building
+
+Before building you'll need a GraalVM setup on your system. Besides intalling the Graal JDK, you'll need to do the following:
+
+1. Set `GRAAL_HOME` to the `JAVA_HOME` of the GraalVM JDK
+2. With the GraalVM active, type `gu install native-image` to install the optional `native-image` tool.
+
+On Ubuntu you might need to do: `sudo apt install gcc g++ binutils`. Similar installs of development tools may be needed on other Linux distros.
 
 The OmniJ Command-line Consensus tool can be built with the following command:
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,16 @@ plugins {
 
 // See gradle.properties for some dependency version settings
 
+buildScan {
+    if (System.getenv('CI')) {
+        publishAlways()
+        uploadInBackground = false
+        tag 'CI'
+    }
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
+
 allprojects {
     apply plugin: 'java'
     apply plugin: 'groovy'

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -29,7 +29,7 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate, RawTxDe
      * RegTest mode after invalidating a block. See OmniJ Issue #185.
      */
     void longerDelayAfterInvalidate() {
-        sleep(30_000)
+        sleep(120_000)
     }
 
     Sha256Hash requestMSC(Address toAddress, OmniDivisibleValue requestedOmni) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.gradle.enterprise" version "3.4"
+}
+
 include 'omnij-core',
         'omnij-dsl',
         'omnij-jsonrpc',    // Omni JSON-RPC pure Java

--- a/test-download-omnicore-ubuntu.sh
+++ b/test-download-omnicore-ubuntu.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+OMNICORE_HOST=https://bintray.com/artifact/download/omni/OmniBinaries
+OMNICORE_RELEASE=omnicore-0.8.2
+OMNICORE_FILE=$OMNICORE_RELEASE-x86_64-linux-gnu.tar.gz
+OMNICORE_HASH=13fad4537f98ab5356454436df6a808995c2c462563d4256a191fea0f10458e9
+
+wget "$OMNICORE_HOST/$OMNICORE_FILE"
+echo "$OMNICORE_HASH  $OMNICORE_FILE" | shasum --algorithm 256 --check
+mkdir -p copied-artifacts/src/
+tar zxvf $OMNICORE_FILE -C /tmp
+mv /tmp/$OMNICORE_RELEASE/bin/omnicored copied-artifacts/src/

--- a/test-omni-integ-regtest.sh
+++ b/test-omni-integ-regtest.sh
@@ -36,7 +36,7 @@ BTCPID=$!
 
 # Run integration tests
 echo "Running Omni RPC integration tests in RegTest mode..."
-./gradlew clean regTest
+./gradlew clean regTest --scan --stacktrace
 GRADLESTATUS=$?
 
 exit $GRADLESTATUS


### PR DESCRIPTION

* If CI, don’t upload Gradle buildscans in background
* Add 3 Github Actions workflows: gradle.yml, regtest.yml, graalvm.yml
* Refactor Omni Core download from .travis.yml to a BASH script named test-download-omnicore-ubuntu.sh
* Add README badges for 3 Github Actions workflows
* GithubCI RegTests upload test results as artifact (on failure, only)
* RegTest increase longerDelayAfterInvalidate (to 120 seconds!)
* Add Gradle caching
*README: Add build note
