### PR TITLE
Fixes to how frozen is handled/totaled.

### DIFF
--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/BalanceEntry.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/BalanceEntry.java
@@ -40,8 +40,7 @@ public class BalanceEntry implements Iterable<OmniValue>  {
 
     public static OmniValue totalBalance(BalanceEntry balanceEntry) {
         return balanceEntry.balance
-                .plus(balanceEntry.reserved)
-                .plus(balanceEntry.frozen);
+                .plus(balanceEntry.reserved);
     }
 
     @Override

--- a/omnij-jsonrpc/src/test/groovy/foundation/omni/rpc/BalanceEntrySpec.groovy
+++ b/omnij-jsonrpc/src/test/groovy/foundation/omni/rpc/BalanceEntrySpec.groovy
@@ -23,7 +23,7 @@ class BalanceEntrySpec extends Specification {
         balanceEntry.balance.bigDecimalValue() == balance
         balanceEntry.reserved.bigDecimalValue() == reserved
         balanceEntry.frozen.bigDecimalValue() == frozen ?: 0
-        BalanceEntry.totalBalance(balanceEntry) == balance + reserved + frozen
+        BalanceEntry.totalBalance(balanceEntry) == balance + reserved
 
 
         where:
@@ -47,7 +47,7 @@ class BalanceEntrySpec extends Specification {
         balanceEntry.balance.longValueExact() == balance
         balanceEntry.reserved.longValueExact() == reserved
         balanceEntry.frozen.longValueExact() == frozen ?: 0
-        BalanceEntry.totalBalance(balanceEntry) == balance + reserved + frozen
+        BalanceEntry.totalBalance(balanceEntry) == balance + reserved
 
 
         where:

--- a/omnij-net-api/src/main/java/foundation/omni/netapi/omniwallet/OmniwalletAbstractClient.java
+++ b/omnij-net-api/src/main/java/foundation/omni/netapi/omniwallet/OmniwalletAbstractClient.java
@@ -171,16 +171,7 @@ public abstract class OmniwalletAbstractClient implements ConsensusService {
         Address address = item.getAddress();
         OmniValue balance = toOmniValue(item.getBalance(), propertyType);
         OmniValue reserved = toOmniValue(item.getReservedBalance(), propertyType);
-        boolean isFrozen = item.isFrozen();
-
-        OmniValue frozen;
-
-        if (isFrozen) {
-            frozen = balance;
-            balance = OmniValue.of(0, propertyType);
-        } else {
-            frozen = OmniValue.of(0, propertyType);
-        }
+        OmniValue frozen = item.isFrozen() ? balance : OmniValue.of(0, propertyType);
 
         return new AddressBalanceEntry(address, balance, reserved, frozen);
     }


### PR DESCRIPTION
In `BalanceEntry.java`, the “total balance” for an address is now:
   `balance` + `reserved`.

When converting from Omniwallet JSON to the Omni Core `BalanceEntry` object,
   `frozen` is either zero or equal to `balance`.