### PR TITLE
CurrencyID: Remove Cloneable and clone()

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ Released: Not yet
 === omnij-core
 
 * Fix bitcoinj deprecation warnings
+* CurrencyID: remove `Cloneable` and `clone()`
 
 === Dependency Updates
 

--- a/omnij-core/src/main/java/foundation/omni/CurrencyID.java
+++ b/omnij-core/src/main/java/foundation/omni/CurrencyID.java
@@ -3,7 +3,7 @@ package foundation.omni;
 /**
  * Omni Protocol Currency ID
  */
-public final class CurrencyID implements Cloneable, Comparable<CurrencyID> {
+public final class CurrencyID implements Comparable<CurrencyID> {
     private final long value;
 
     public static final long   MIN_VALUE = 0;
@@ -141,13 +141,5 @@ public final class CurrencyID implements Cloneable, Comparable<CurrencyID> {
     @Override
     public int compareTo(CurrencyID o) {
         return Long.compare(this.value, o.value);
-    }
-
-    /**
-     * Make a clone of this object (also used by Groovy's @Immutable annotation)
-     * @return a clone
-     */
-    public CurrencyID clone() {
-        return new CurrencyID(this.value);
     }
 }


### PR DESCRIPTION
Cloneable/clone() should not be necessary for an immutable object and is not a best practice according to Effective Java.