### PR TITLE
Add new RPC "omni_sendtomany" with example

### DIFF
--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -2,24 +2,17 @@ package foundation.omni.rpc;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
-import com.google.common.primitives.UnsignedBytes;
-import org.consensusj.bitcoin.rpc.BitcoinExtendedClient;
-import foundation.omni.json.pojo.OmniPropertyInfo;
-import org.bitcoinj.core.LegacyAddress;
-import org.bitcoinj.core.SegwitAddress;
-import org.consensusj.bitcoin.rx.jsonrpc.RxBitcoinClient;
-import org.consensusj.jsonrpc.JsonRpcException;
-import org.consensusj.bitcoin.rpc.RpcConfig;
-import foundation.omni.CurrencyID;
-import foundation.omni.Ecosystem;
-import foundation.omni.OmniValue;
-import foundation.omni.PropertyType;
+import foundation.omni.*;
 import foundation.omni.json.conversion.OmniClientModule;
+import foundation.omni.json.pojo.OmniPropertyInfo;
 import foundation.omni.net.OmniNetworkParameters;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
+import org.consensusj.bitcoin.rpc.RpcConfig;
+import org.consensusj.bitcoin.rx.jsonrpc.RxBitcoinClient;
+import org.consensusj.jsonrpc.JsonRpcException;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
@@ -28,7 +21,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.TreeMap;
 
 // TODO: add missing RPCs:
 // - omni_listtransactions
@@ -309,6 +301,22 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
     public Sha256Hash omniSendAll(Address fromAddress, Address toAddress, Ecosystem ecosystem)
             throws JsonRpcException, IOException {
         return send("omni_sendall", Sha256Hash.class, fromAddress, toAddress, ecosystem);
+    }
+
+    /**
+     * Creates and broadcasts a "send to many" transaction.
+     *
+     * @param fromAddress The address to spent from
+     * @param currency    The identifier of the token to distribute
+     * @param mapping     The receiving addresses and amounts as list of OmniOutput
+     * @return The hash of the transaction
+     * @throws JsonRpcException JSON RPC error
+     * @throws IOException network error
+     * @since Omni Core 0.0.12
+     */
+    public Sha256Hash omniSendToMany(Address fromAddress, CurrencyID currency, List<OmniOutput> mapping)
+            throws JsonRpcException, IOException {
+        return send("omni_sendtomany", Sha256Hash.class, fromAddress, currency, mapping);
     }
 
     /**

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendtomany/SendToManySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendtomany/SendToManySpec.groovy
@@ -1,0 +1,132 @@
+package foundation.omni.test.rpc.sendtomany
+
+import foundation.omni.BaseRegTestSpec
+import foundation.omni.CurrencyID
+import foundation.omni.OmniOutput
+import foundation.omni.OmniValue
+import org.junit.AssumptionViolatedException
+
+class SendToManySpec extends BaseRegTestSpec {
+
+    final static startBTC = 0.1.btc
+    final static startOmni = 1.0.divisible
+
+    def "Send to many with seven receivers with Class C encoding"() {
+        when:
+        def actorAddress = createFundedAddress(startBTC, startOmni)
+        def otherAddress1 = newAddress
+        def otherAddress2 = newAddress
+        def otherAddress3 = newAddress
+        def otherAddress4 = newAddress
+        def otherAddress5 = newAddress
+        def otherAddress6 = newAddress
+        def otherAddress7 = newAddress
+
+        def mapping = [
+                new OmniOutput(otherAddress1, 0.00000001.divisible),
+                new OmniOutput(otherAddress2, 0.00000002.divisible),
+                new OmniOutput(otherAddress3, 0.00000003.divisible),
+                new OmniOutput(otherAddress4, 0.00000004.divisible),
+                new OmniOutput(otherAddress5, 0.00000005.divisible),
+                new OmniOutput(otherAddress6, 0.00000006.divisible),
+                new OmniOutput(otherAddress7, 0.00000007.divisible)
+        ]
+
+        then:
+        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startOmni.numberValue()
+
+        when: "sending to seven receivers"
+        def sendTxid = omniSendToMany(actorAddress, CurrencyID.OMNI, mapping)
+        generateBlocks(1)
+        def sendTx = omniGetTransaction(sendTxid)
+
+        then: "the transaction is valid and all destinations receivers the correct balance"
+        sendTx.valid
+        OmniValue.of(sendTx.totalamount) == 0.00000028.divisible
+        omniGetBalance(otherAddress1, CurrencyID.OMNI).balance == 0.00000001.divisible
+        omniGetBalance(otherAddress2, CurrencyID.OMNI).balance == 0.00000002.divisible
+        omniGetBalance(otherAddress3, CurrencyID.OMNI).balance == 0.00000003.divisible
+        omniGetBalance(otherAddress4, CurrencyID.OMNI).balance == 0.00000004.divisible
+        omniGetBalance(otherAddress5, CurrencyID.OMNI).balance == 0.00000005.divisible
+        omniGetBalance(otherAddress6, CurrencyID.OMNI).balance == 0.00000006.divisible
+        omniGetBalance(otherAddress7, CurrencyID.OMNI).balance == 0.00000007.divisible
+    }
+
+    def "Send to many with eight receivers with Class B encoding"() {
+        when:
+        def actorAddress = createFundedAddress(startBTC, startOmni)
+        def otherAddress1 = newAddress
+        def otherAddress2 = newAddress
+        def otherAddress3 = newAddress
+        def otherAddress4 = newAddress
+        def otherAddress5 = newAddress
+        def otherAddress6 = newAddress
+        def otherAddress7 = newAddress
+        def otherAddress8 = newAddress
+
+        def mapping = [
+                new OmniOutput(otherAddress1, 0.00000001.divisible),
+                new OmniOutput(otherAddress2, 0.00000002.divisible),
+                new OmniOutput(otherAddress3, 0.00000003.divisible),
+                new OmniOutput(otherAddress4, 0.00000004.divisible),
+                new OmniOutput(otherAddress5, 0.00000005.divisible),
+                new OmniOutput(otherAddress6, 0.00000006.divisible),
+                new OmniOutput(otherAddress7, 0.00000007.divisible),
+                new OmniOutput(otherAddress8, 0.00000008.divisible)
+        ]
+
+        then:
+        omniGetBalance(actorAddress, CurrencyID.OMNI).balance == startOmni.numberValue()
+
+        when: "sending to eight receivers"
+        def sendTxid = omniSendToMany(actorAddress, CurrencyID.OMNI, mapping)
+        generateBlocks(1)
+        def sendTx = omniGetTransaction(sendTxid)
+
+        then: "the transaction is valid and all destinations receivers the correct balance"
+        sendTx.valid
+        OmniValue.of(sendTx.totalamount) == 0.00000036.divisible
+        omniGetBalance(otherAddress1, CurrencyID.OMNI).balance == 0.00000001.divisible
+        omniGetBalance(otherAddress2, CurrencyID.OMNI).balance == 0.00000002.divisible
+        omniGetBalance(otherAddress3, CurrencyID.OMNI).balance == 0.00000003.divisible
+        omniGetBalance(otherAddress4, CurrencyID.OMNI).balance == 0.00000004.divisible
+        omniGetBalance(otherAddress5, CurrencyID.OMNI).balance == 0.00000005.divisible
+        omniGetBalance(otherAddress6, CurrencyID.OMNI).balance == 0.00000006.divisible
+        omniGetBalance(otherAddress7, CurrencyID.OMNI).balance == 0.00000007.divisible
+        omniGetBalance(otherAddress8, CurrencyID.OMNI).balance == 0.00000008.divisible
+    }
+
+    def "Send to many with 221 receivers with Class B encoding"() {
+        when:
+        def actorAddress = createFundedAddress(startBTC, startOmni)
+        def otherAddressA = newAddress
+        def otherAddressB = newAddress
+
+        ArrayList<OmniOutput> mapping = []
+        for (def i = 0; i < 220; i++) {
+            mapping.add(new OmniOutput(otherAddressA, 0.00000001.divisible))
+        }
+        mapping.add(new OmniOutput(otherAddressB, 0.00000007.divisible))
+
+        then:
+        omniGetBalance(actorAddress, CurrencyID.TOMNI).balance == startOmni.numberValue()
+
+        when: "sending to 220 receivers"
+        def sendTxid = omniSendToMany(actorAddress, CurrencyID.TOMNI, mapping)
+        generateBlocks(1)
+        def sendTx = omniGetTransaction(sendTxid)
+
+        then: "the transaction is valid and the receiver received the correct number of tokens"
+        sendTx.valid
+        OmniValue.of(sendTx.totalamount) == 0.00000227.divisible
+        omniGetBalance(otherAddressA, CurrencyID.TOMNI).balance == 0.00000220.divisible
+        omniGetBalance(otherAddressB, CurrencyID.TOMNI).balance == 0.00000007.divisible
+    }
+
+    def setupSpec() {
+        if (!commandExists("omni_sendtomany")) {
+            throw new AssumptionViolatedException('The client has no "omni_sendtomany" command')
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request adds the new RPC `"omni_sendtomany"` with an example.

Please note, ideally we would pass a list of `Address` and `OmniValue` objects, instead of manually converting into strings within the test.