### PR TITLE
Add OmniOutput with serializer and deserializer

### DIFF
--- a/omnij-core/src/main/java/foundation/omni/OmniOutput.java
+++ b/omnij-core/src/main/java/foundation/omni/OmniOutput.java
@@ -1,0 +1,24 @@
+package foundation.omni;
+
+import org.bitcoinj.core.Address;
+
+/**
+ * A record-like container for an amount and a destination address. Intended for {@code omni_sendmany}.
+ */
+public class OmniOutput {
+    private final Address address;
+    private final OmniValue amount;
+
+    public OmniOutput(Address address, OmniValue amount) {
+        this.address = address;
+        this.amount = amount;
+    }
+
+    public Address address() {
+        return address;
+    }
+
+    public OmniValue amount() {
+        return amount;
+    }
+}

--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniClientModule.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniClientModule.java
@@ -2,6 +2,7 @@ package foundation.omni.json.conversion;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import foundation.omni.OmniOutput;
 import org.consensusj.bitcoin.json.conversion.AddressDeserializer;
 import foundation.omni.CurrencyID;
 import foundation.omni.Ecosystem;
@@ -25,10 +26,12 @@ public class OmniClientModule extends SimpleModule {
         this.addDeserializer(CurrencyID.class, new CurrencyIDDeserializer())
             .addDeserializer(AddressBalanceEntries.class, new AddressBalanceEntriesDeserializer())
             .addDeserializer(OmniValue.class, new OmniValueDeserializer())
+            .addDeserializer(OmniOutput.class, new OmniOutputDeserializer())
             .addDeserializer(PropertyBalanceEntries.class, new PropertyBalanceEntriesDeserializer())
             .addSerializer(CurrencyID.class, new CurrencyIDSerializer())
             .addSerializer(Ecosystem.class, new EcosystemSerializer())
             .addSerializer(PropertyType.class, new PropertyTypeSerializer())
-            .addSerializer(OmniValue.class, new OmniValueSerializer());
+            .addSerializer(OmniValue.class, new OmniValueSerializer())
+            .addSerializer(OmniOutput.class, new OmniOutputSerializer());
     }
 }

--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniOutputDeserializer.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniOutputDeserializer.java
@@ -1,0 +1,36 @@
+package foundation.omni.json.conversion;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import foundation.omni.OmniOutput;
+import foundation.omni.OmniValue;
+import foundation.omni.PropertyType;
+import org.bitcoinj.core.Address;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for record-like {@link OmniOutput}
+ */
+public class OmniOutputDeserializer extends JsonDeserializer<OmniOutput> {
+    @Override
+    public OmniOutput deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JacksonException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        String address = node.get("address").asText();
+        String amount = node.get("amount").asText();
+        return new OmniOutput(Address.fromString(null, address), omniValueFromString(amount));
+    }
+
+    static OmniValue omniValueFromString(String val) {
+        boolean divisible = val.contains(".");  // Divisible amounts always contain a decimal point
+        if (divisible) {
+            return OmniValue.of(new BigDecimal(val), PropertyType.DIVISIBLE);
+        } else {
+            return OmniValue.of(Long.parseLong(val), PropertyType.INDIVISIBLE);
+        }
+    }
+}

--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniOutputSerializer.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniOutputSerializer.java
@@ -1,0 +1,21 @@
+package foundation.omni.json.conversion;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import foundation.omni.OmniOutput;
+
+import java.io.IOException;
+
+/**
+ * Serializer for record-like {@link OmniOutput}
+ */
+public class OmniOutputSerializer extends JsonSerializer<OmniOutput> {
+    @Override
+    public void serialize(OmniOutput value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField("address", value.address().toString());
+        gen.writeStringField("amount", value.amount().toJsonFormattedString());
+        gen.writeEndObject();
+    }
+}

--- a/omnij-jsonrpc/src/test/groovy/foundation/omni/json/conversion/OmniOutputJsonSpec.groovy
+++ b/omnij-jsonrpc/src/test/groovy/foundation/omni/json/conversion/OmniOutputJsonSpec.groovy
@@ -1,0 +1,43 @@
+package foundation.omni.json.conversion
+
+import com.fasterxml.jackson.databind.module.SimpleModule
+import foundation.omni.OmniOutput
+import foundation.omni.net.OmniTestNetParams
+
+/**
+ * Basic test of serialization/deserialization of {@link OmniOutput}
+ */
+class OmniOutputJsonSpec extends BaseObjectMapperSpec {
+
+    def "serialize"() {
+        given:
+        OmniOutput output = new OmniOutput(OmniTestNetParams.get().exodusAddress, 123.divisible)
+
+        when:
+        String serialized = mapper.writeValueAsString(output)
+
+        then:
+        serialized == '{"address":"mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv","amount":"123.0"}'
+    }
+
+
+    def "deserialize"() {
+        given:
+        String serialized = '{"address":"mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv","amount":"123.0"}'
+
+        when:
+        OmniOutput output = mapper.readValue(serialized, OmniOutput.class)
+
+        then:
+        output != null
+        output.address() == OmniTestNetParams.get().exodusAddress
+        output.amount() == 123.divisible
+
+    }
+
+    @Override
+    def configureModule(SimpleModule module) {
+        module.addSerializer(OmniOutput.class, new OmniOutputSerializer())
+        module.addDeserializer(OmniOutput.class, new OmniOutputDeserializer())
+    }
+}


### PR DESCRIPTION
`omnij-core`:

* OmniOutput: A record-like container for an address and an amount

`omnij-jsonrpc`:

Serialization and deserialization support, added to `OmniClientModule` to be included in the Omni JSON-RPC client.