### PR TITLE
OmniValue: add of(String) methods

### DIFF
--- a/omnij-core/src/main/java/foundation/omni/OmniValue.java
+++ b/omnij-core/src/main/java/foundation/omni/OmniValue.java
@@ -65,6 +65,35 @@ public abstract class OmniValue extends NumberValue {
         return divisible ? OmniDivisibleValue.of(amount) : OmniIndivisibleValue.of(amount);
     }
 
+    /**
+     * Parse a {@code String} (which should be in OmniValue JSON format) to get an {@code OmniValue}
+     * <p>
+     * WARNING: This method requires that all amounts for {@link OmniDivisibleValue} <b>must contain a decimal point</b>
+     * to be properly parsed into an {@code OmniDivisibleValue} representation. See {@link OmniValue#toJsonFormattedString()} for
+     * details.
+     * @param omniValueJsonFormattedString A string representation of an OmniValue in OmniValue JSON format
+     * @return An {@link OmniDivisibleValue} if the string contains a {@code '.'}, otherwise an {@link OmniIndivisibleValue}
+     * @throws NumberFormatException if the string is not parseable.
+     */
+    public static OmniValue of(String omniValueJsonFormattedString) {
+        if (omniValueJsonFormattedString.contains(".")) {
+            return OmniValue.of(new BigDecimal(omniValueJsonFormattedString), PropertyType.DIVISIBLE);
+        } else {
+            return OmniValue.of(Long.parseLong(omniValueJsonFormattedString), PropertyType.INDIVISIBLE);
+        }
+    }
+
+    /**
+     * Parse a numeric {@code String} to get an {@code OmniValue}
+     * @param string A string that should be parseable to a {@link BigDecimal}
+     * @param divisible whether this string represents a divisible value, false otherwise
+     * @return An {@link OmniDivisibleValue} or {@link OmniIndivisibleValue} depending upon the {@code divisible} parameter
+     * @throws NumberFormatException if the string is not parseable.
+     */
+    public static OmniValue of(String string, boolean divisible) {
+        return OmniValue.of(new BigDecimal(string), divisible);
+    }
+
     public static OmniValue ofWilletts(long amount, PropertyType type) {
         return ofWilletts(amount, type.equals(PropertyType.DIVISIBLE));
     }

--- a/omnij-core/src/test/groovy/foundation/omni/OmniValueSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/OmniValueSpec.groovy
@@ -10,6 +10,34 @@ import spock.lang.Unroll
 class OmniValueSpec extends Specification {
 
     @Unroll
+    def "of(String) parses #string to the #expectedSubclass subclass and #expectedValue"(String string, Class<?> expectedSubclass, OmniValue expectedValue) {
+        when:
+        var val = OmniValue.of(string)
+
+        then:
+        val.getClass() == expectedSubclass
+        val == expectedValue
+
+        where:
+        string          | expectedSubclass              | expectedValue
+        "0"             | OmniIndivisibleValue.class    | OmniIndivisibleValue.of(0)
+        "0.0"           | OmniDivisibleValue.class      | OmniDivisibleValue.of(0)
+        "0.00000001"    | OmniDivisibleValue.class      | OmniDivisibleValue.ofWilletts(1)
+    }
+
+    @Unroll
+    def "of(String) throws NumberFormatException for invalid string: #string"(String string) {
+        when:
+        var val = OmniValue.of(string)
+
+        then:
+        thrown(NumberFormatException)
+
+        where:
+        string << ["yak", "@!%#"]
+    }
+
+    @Unroll
     def "checkValue does not throw exception for valid long value: #val" (long val) {
         when: "we check the value"
         OmniValue.checkWillettValue(val)

--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniOutputDeserializer.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniOutputDeserializer.java
@@ -22,15 +22,6 @@ public class OmniOutputDeserializer extends JsonDeserializer<OmniOutput> {
         JsonNode node = jp.getCodec().readTree(jp);
         String address = node.get("address").asText();
         String amount = node.get("amount").asText();
-        return new OmniOutput(Address.fromString(null, address), omniValueFromString(amount));
-    }
-
-    static OmniValue omniValueFromString(String val) {
-        boolean divisible = val.contains(".");  // Divisible amounts always contain a decimal point
-        if (divisible) {
-            return OmniValue.of(new BigDecimal(val), PropertyType.DIVISIBLE);
-        } else {
-            return OmniValue.of(Long.parseLong(val), PropertyType.INDIVISIBLE);
-        }
+        return new OmniOutput(Address.fromString(null, address), OmniValue.of(amount));
     }
 }

--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniValueDeserializer.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/conversion/OmniValueDeserializer.java
@@ -22,12 +22,7 @@ public class OmniValueDeserializer extends JsonDeserializer<OmniValue> {
         switch (token) {
             case VALUE_STRING:
                 String val = p.getValueAsString();
-                boolean divisible = val.contains(".");  // Divisible amounts always contain a decimal point
-                if (divisible) {
-                    return OmniValue.of(new BigDecimal(val), PropertyType.DIVISIBLE);
-                } else {
-                    return OmniValue.of(p.getValueAsLong(), PropertyType.INDIVISIBLE);
-                }
+                return OmniValue.of(val);
             default:
                 ctxt.handleUnexpectedToken(Sha256Hash.class, p);
                 return null;

--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/pojo/OmniPropertyInfo.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/pojo/OmniPropertyInfo.java
@@ -59,7 +59,7 @@ public class OmniPropertyInfo extends SmartPropertyListInfo {
                 fixedIssuance,
                 managedIssuance,
                 freezingEnabled,
-                OmniValue.of(new BigDecimal(totaltokensString), divisible));
+                OmniValue.of(totaltokensString, divisible));
     }
 
     public OmniPropertyInfo(CurrencyID propertyid,

--- a/omnij-net-api/src/main/java/foundation/omni/netapi/omniwallet/OmniwalletAbstractClient.java
+++ b/omnij-net-api/src/main/java/foundation/omni/netapi/omniwallet/OmniwalletAbstractClient.java
@@ -231,15 +231,6 @@ public abstract class OmniwalletAbstractClient implements ConsensusService, RxOm
         return new AddressBalanceEntry(address, balance, reserved, frozen);
     }
 
-    protected static OmniValue stringToOmniValue(String valueString) {
-        boolean divisible = valueString.contains(".");  // Divisible amounts always contain a decimal point
-        if (divisible) {
-            return OmniValue.of(new BigDecimal(valueString), PropertyType.DIVISIBLE);
-        } else {
-            return OmniValue.of(Long.parseLong(valueString), PropertyType.INDIVISIBLE);
-        }
-    }
-
     protected SmartPropertyListInfo mapToSmartPropertyListInfo(OmniwalletPropertyInfo property) {
         return new SmartPropertyListInfo(property.getPropertyid(),
                     property.getName(),

--- a/omnij-net-api/src/main/java/foundation/omni/netapi/omniwallet/json/OmniwalletPropertyInfo.java
+++ b/omnij-net-api/src/main/java/foundation/omni/netapi/omniwallet/json/OmniwalletPropertyInfo.java
@@ -62,7 +62,7 @@ public class OmniwalletPropertyInfo {
         this.name = name;
         this.propertyid = propertyid;
         this.subcategory = subcategory;
-        this.totalTokens = OmniValue.of(new BigDecimal(totalTokensString), divisible);
+        this.totalTokens = OmniValue.of(totalTokensString, divisible);
         this.url = url;
     }
 


### PR DESCRIPTION
... as requested by @dexX7 .

I was reluctant to add this because I was concerned that an `.of(String string)` method might not be used properly (it should only be used with strings that use the Omni Core "JSON formatted" convention of _always_ using decimals in strings for divisible amounts and _never_ using decimals in strings of indivisible amounts.

But given that **OmniJ** itself already had multiple implementations of this method, I guess it makes sense to just add it to `OmniValue`.

I also tried to make the above concern well-documented in the JavaDoc.