### PR TITLE
Deprecate and stop using RawTxDelegate

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersSpec.groovy
@@ -1,5 +1,6 @@
 package foundation.omni.test.rpc.sto
 
+import foundation.omni.tx.RawTxBuilder
 import org.consensusj.jsonrpc.JsonRpcStatusException
 import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
@@ -86,7 +87,8 @@ class SendToOwnersSpec extends BaseRegTestSpec {
 
     def "The generated hex-encoded transaction matches a valid reference transaction"() {
         given:
-        def txHex = createSendToOwnersHex(new CurrencyID(6L), 100000000000.indivisible)
+        RawTxBuilder builder = new RawTxBuilder()
+        def txHex = builder.createSendToOwnersHex(new CurrencyID(6L), 100000000000.indivisible)
         def expectedHex = "0000000300000006000000174876e800"
 
         expect:

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanRawSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanRawSpec.groovy
@@ -3,6 +3,7 @@ package foundation.omni.test.rpc.sto
 //import org.consensusj.bitcoin.jsonrpc.conversion.BitcoinMath
 import foundation.omni.CurrencyID
 import foundation.omni.OmniValue
+import foundation.omni.tx.RawTxBuilder
 import org.bitcoinj.core.Address
 
 /**
@@ -16,7 +17,8 @@ class SendToOwnersTestPlanRawSpec extends SendToOwnersTestPlanSpec {
      */
     @Override
     def executeSendToOwners(Address address, CurrencyID currency, OmniValue amount, Boolean exceptional=false) {
-        def rawTxHex = createSendToOwnersHex(currency, amount);
+        RawTxBuilder builder = new RawTxBuilder()
+        def rawTxHex = builder.createSendToOwnersHex(currency, amount);
         def txid = omniSendRawTx(address, rawTxHex)
         return txid
     }

--- a/omnij-rpc/src/main/groovy/foundation/omni/rpc/RawTxDelegate.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/rpc/RawTxDelegate.groovy
@@ -4,7 +4,9 @@ import foundation.omni.tx.RawTxBuilder
 
 /**
  * Add raw Tx creation to any class
+ * @deprecated Don't use delegation, keep a reference to a RawTxBuilder object
  */
+@Deprecated
 trait RawTxDelegate {
     @Delegate
     RawTxBuilder builder = new RawTxBuilder()

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -5,7 +5,6 @@ import foundation.omni.Ecosystem
 import foundation.omni.OmniDivisibleValue
 import foundation.omni.OmniValue
 import foundation.omni.PropertyType
-import foundation.omni.rpc.RawTxDelegate
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.Sha256Hash
@@ -18,7 +17,7 @@ import java.math.RoundingMode
 /**
  * Test support functions intended to be mixed-in to Spock test specs
  */
-trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate, RawTxDelegate {
+trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
     private static final Logger log = LoggerFactory.getLogger(OmniTestSupport.class);
 
     /**


### PR DESCRIPTION
The tests that need a RawRxBuilder have been changed to just allocate on locally.