### PR TITLE
Upgrade to ConsensusJ v0.6.4 (add support for Bitcoin Core v23.0)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ useMavenLocal = false
 
 bitcoinjVersion = 0.16.1
 consensusjGroup = com.msgilligan
-consensusjVersion = 0.6.3
+consensusjVersion = 0.6.4
 slf4jVersion = 2.0.3
 groovyVersion = 4.0.5
 spockVersion = 2.3-groovy-4.0

--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/test/OmniTestClientAccessor.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/test/OmniTestClientAccessor.java
@@ -1,0 +1,21 @@
+package foundation.omni.rpc.test;
+
+/**
+ * Interface for tests that use a BitcoinExtendedClient
+ */
+public interface OmniTestClientAccessor {
+
+    /**
+     * Preferred accessor
+     * @return The Omni Client
+     */
+    OmniTestClient client();
+
+    /**
+     * JavaBeans style getter/accessor (for Groovy, etc)
+     * @return The Omni Client
+     */
+    default OmniTestClient getClient() {
+        return client();
+    }
+}

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/activation/BaseActivationSpec.groovy
@@ -41,16 +41,16 @@ abstract class BaseActivationSpec extends BaseRegTestSpec {
     @Shared Sha256Hash initialBlock
 
     def setupSpec() {
-        if (!commandExists('omni_sendactivation')) {
+        if (!client.commandExists('omni_sendactivation')) {
             throw new AssumptionViolatedException('The client has no "omni_sendactivation" command')
         }
-        if (!commandExists('omni_getactivations')) {
+        if (!client.commandExists('omni_getactivations')) {
             throw new AssumptionViolatedException('The client has no "omni_getactivations" command')
         }
 
-        generateBlocks(1)
-        def currentBlockCount = getBlockCount()
-        initialBlock = getBlockHash(currentBlockCount)
+        client.generateBlocks(1)
+        def currentBlockCount = client.getBlockCount()
+        initialBlock = client.getBlockHash(currentBlockCount)
     }
 
     def cleanupSpec() {

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/scripts/OmniCreateTokenScriptSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/scripts/OmniCreateTokenScriptSpec.groovy
@@ -1,12 +1,14 @@
 package foundation.omni.test.scripts
 
 import foundation.omni.scripts.omniCreateToken
+import spock.lang.Ignore
 import spock.lang.Specification
 
 
 /**
  * Just run the script and make sure its assert doesn't fail
  */
+@Ignore("This isn't used or supported currently")
 class OmniCreateTokenScriptSpec extends Specification {
     def "run the omniCreateToken.groovy script"() {
         expect:

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestClientDelegate.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestClientDelegate.groovy
@@ -4,7 +4,9 @@ import foundation.omni.rpc.test.OmniTestClient
 
 /**
  * Groovy trait for adding an OmniTestClient delegate to any class
+ * @deprecated Use {@code @Delegate OmniTestClient client} directly
  */
+@Deprecated
 trait OmniTestClientDelegate {
     @Delegate
     OmniTestClient client

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/OmniTestSupport.groovy
@@ -1,5 +1,6 @@
 package foundation.omni.test
 
+import foundation.omni.rpc.test.OmniTestClientAccessor
 import org.consensusj.bitcoin.jsonrpc.groovy.test.BTCTestSupport
 import foundation.omni.Ecosystem
 import foundation.omni.OmniDivisibleValue
@@ -9,6 +10,7 @@ import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.Sha256Hash
 import foundation.omni.CurrencyID
+import org.consensusj.bitcoin.jsonrpc.test.FundingSourceAccessor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -17,14 +19,14 @@ import java.math.RoundingMode
 /**
  * Test support functions intended to be mixed-in to Spock test specs
  */
-trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
-    private static final Logger log = LoggerFactory.getLogger(OmniTestSupport.class);
+interface OmniTestSupport extends OmniTestClientAccessor, FundingSourceAccessor, BTCTestSupport {
+    static final Logger log = LoggerFactory.getLogger(OmniTestSupport.class);
 
     /**
      * Delay long enough to avoid Duplicate block errors when resubmitting blocks in
      * RegTest mode after invalidating a block. See OmniJ Issue #185.
      */
-    void delayAfterInvalidate() {
+    default void delayAfterInvalidate() {
         sleep(2_000)
     }
 
@@ -32,11 +34,11 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
      * Longer delay to avoid Duplicate block errors when resubmitting blocks in
      * RegTest mode after invalidating a block. See OmniJ Issue #185.
      */
-    void longerDelayAfterInvalidate() {
+    default void longerDelayAfterInvalidate() {
         sleep(120_000)
     }
 
-    Sha256Hash requestOmni(Address toAddress, OmniDivisibleValue requestedOmni) {
+    default Sha256Hash requestOmni(Address toAddress, OmniDivisibleValue requestedOmni) {
         return requestOmni(toAddress, requestedOmni, true)
     }
 
@@ -49,7 +51,7 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
      * @param allowIntermediate allow intermediate receiver
      * @return txid
      */
-    Sha256Hash requestOmni(Address toAddress, OmniDivisibleValue requestedOmni, Boolean allowIntermediate) {
+    default Sha256Hash requestOmni(Address toAddress, OmniDivisibleValue requestedOmni, Boolean allowIntermediate) {
         // For 1.0 BTC an amount of 100.0 OMNI is generated, resulting in a minimal purchase amount of
         // 0.00000100 OMNI for 0.00000001 BTC
         Coin btcForOmni = (requestedOmni.willetts / 100).setScale(0, RoundingMode.UP).satoshi
@@ -59,71 +61,71 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
             assert actualOmni == requestedOmni
         }
 
-        requestBitcoin(toAddress, btcForOmni + stdTxFee)
-        def txid = sendBitcoin(toAddress, omniNetParams.moneyManAddress, btcForOmni)
+        fundingSource().requestBitcoin(toAddress, btcForOmni + client().stdTxFee)
+        def txid = client().sendBitcoin(toAddress, client().omniNetParams.moneyManAddress, btcForOmni)
 
         if (actualOmni.willetts != requestedOmni.willetts) {
             def excessiveOmni = actualOmni - requestedOmni
 
             // TODO: avoid magic numbers for dust calculation
             // TODO: convert calculations to Coin type or integer
-            BigDecimal dustForExodus = ((((148 + 34) * 3) / 1000) * stdRelayTxFee.value).setScale(8, RoundingMode.UP)
-            BigDecimal dustForReference = ((((148 + 34) * 3) / 1000) * stdRelayTxFee.value).setScale(8, RoundingMode.UP)
-            BigDecimal dustForPayload = ((((148 + 80) * 3) / 1000) * stdRelayTxFee.value).setScale(8, RoundingMode.UP)
+            BigDecimal dustForExodus = ((((148 + 34) * 3) / 1000) * client().stdRelayTxFee.value).setScale(8, RoundingMode.UP)
+            BigDecimal dustForReference = ((((148 + 34) * 3) / 1000) * client().stdRelayTxFee.value).setScale(8, RoundingMode.UP)
+            BigDecimal dustForPayload = ((((148 + 80) * 3) / 1000) * client().stdRelayTxFee.value).setScale(8, RoundingMode.UP)
 
             // Simple send transactions have a dust output for the receiver reference, a marker output and an output
             // for the actual payload. OMNI and TOMNI are forwarded in two transactions, so this amount, as well as the
             // transaction fee, have to be paid twice
-            BigDecimal additionalRequiredDecimal = (dustForExodus + dustForReference + dustForPayload + stdTxFee.value) * 2
+            BigDecimal additionalRequiredDecimal = (dustForExodus + dustForReference + dustForPayload + client().stdTxFee.value) * 2
             Coin additionalRequired = additionalRequiredDecimal.satoshi
             log.debug "requestOmni: requesting ${additionalRequired} additional bitcoin"
-            requestBitcoin(toAddress, additionalRequired)
+            fundingSource().requestBitcoin(toAddress, additionalRequired)
 
             // The excessive amount of OMNI is sent to a new address to get rid of it
-            def junkAddress = newAddress
+            def junkAddress = client().newAddress
 
             // TODO: can we always get away with not generating a block inbetween?
-            def extraTxidOmni = omniSend(toAddress, junkAddress, CurrencyID.OMNI, excessiveOmni)
-            def extraTxidTOmni = omniSend(toAddress, junkAddress, CurrencyID.TOMNI, excessiveOmni)
+            def extraTxidOmni = client().omniSend(toAddress, junkAddress, CurrencyID.OMNI, excessiveOmni)
+            def extraTxidTOmni = client().omniSend(toAddress, junkAddress, CurrencyID.TOMNI, excessiveOmni)
         }
 
         // TODO: when using an intermediate receiver, this txid doesn't reflect the whole picture
         return txid
     }
 
-    Address createFundedAddress(Coin requestedBTC, OmniValue requestedOmni) {
+    default Address createFundedAddress(Coin requestedBTC, OmniValue requestedOmni) {
         return createFundedAddress(requestedBTC, requestedOmni, true)
     }
 
-    Address createFundedAddress(Coin requestedBTC, OmniValue requestedOmni, Boolean confirmTransactions) {
+    default Address createFundedAddress(Coin requestedBTC, OmniValue requestedOmni, Boolean confirmTransactions) {
         log.debug "createFundedAddress: requestedBTC: {}, requestedOmni: {}, confirm: {}", requestedBTC.toFriendlyString(), requestedOmni, confirmTransactions
-        def fundedAddress = newAddress
+        def fundedAddress = client().newAddress
 
         if (requestedOmni.willetts > 0) {
             def txidOmni = requestOmni(fundedAddress, (OmniDivisibleValue) requestedOmni)
         }
 
         if (requestedBTC.value > 0) {
-            def txidBTC = requestBitcoin(fundedAddress, requestedBTC)
+            def txidBTC = fundingSource().requestBitcoin(fundedAddress, requestedBTC)
         }
 
         if (confirmTransactions) {
-            generateBlocks(1)
+            client().generateBlocks(1)
         }
 
         // TODO: maybe add assertions to check correct funding amounts?
         Boolean check = true
         if (check && confirmTransactions) {
-            assert getBitcoinBalance(fundedAddress).value >= requestedBTC.value
-            assert omniGetBalance(fundedAddress, CurrencyID.OMNI).balance >= requestedOmni.numberValue()
+            assert client().getBitcoinBalance(fundedAddress).value >= requestedBTC.value
+            assert client().omniGetBalance(fundedAddress, CurrencyID.OMNI).balance >= requestedOmni.numberValue()
             log.debug "balances verified, fundedAddress has {} and {} Omni", requestedBTC.toFriendlyString(), requestedOmni
         }
 
         return fundedAddress
     }
 
-    CurrencyID fundNewProperty(Address address, OmniValue amount, Ecosystem ecosystem) {
-        def txidCreation = omniSendIssuanceFixed(address,
+    default CurrencyID fundNewProperty(Address address, OmniValue amount, Ecosystem ecosystem) {
+        def txidCreation = client().omniSendIssuanceFixed(address,
                 ecosystem,
                 amount.getPropertyType(),
                 CurrencyID.of(0),   // previousId (0 means new token)
@@ -134,15 +136,15 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
                 "",
                 amount);
 
-        generateBlocks(1)
-        def txCreation = omniGetTransaction(txidCreation)
+        client().generateBlocks(1)
+        def txCreation = client().omniGetTransaction(txidCreation)
         assert txCreation.valid
         assert txCreation.confirmations == 1
         return txCreation.propertyId
     }
 
-    CurrencyID fundManagedProperty(Address address, PropertyType type, Ecosystem ecosystem) {
-        def txidCreation = omniSendIssuanceManaged(address,
+    default CurrencyID fundManagedProperty(Address address, PropertyType type, Ecosystem ecosystem) {
+        def txidCreation = client().omniSendIssuanceManaged(address,
                 ecosystem,
                 type,
                 CurrencyID.of(0),   // previousId (0 means new token)
@@ -151,8 +153,8 @@ trait OmniTestSupport implements BTCTestSupport, OmniTestClientDelegate {
                 "MSP",
                 "",
                 "")
-        generateBlocks(1)
-        def txCreation = omniGetTransaction(txidCreation)
+        client().generateBlocks(1)
+        def txCreation = client().omniGetTransaction(txidCreation)
         assert txCreation.valid
         assert txCreation.confirmations == 1
         return new CurrencyID(txCreation.propertyId as long)

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/RegTestContext.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/RegTestContext.groovy
@@ -4,6 +4,7 @@ import foundation.omni.rpc.test.OmniTestClient
 import org.consensusj.bitcoin.jsonrpc.RpcURI
 import org.consensusj.bitcoin.jsonrpc.test.RegTestEnvironment
 import org.bitcoinj.params.RegTestParams
+import org.consensusj.bitcoin.jsonrpc.test.RegTestFundingSource
 
 /**
  *
@@ -12,7 +13,7 @@ class RegTestContext {
     static setup(String user, String pass) {
         def client = new OmniTestClient(RegTestParams.get(), RpcURI.defaultRegTestURI, user, pass)
         def env = new RegTestEnvironment(client)
-        def funder = new RegTestOmniFundingSource(client)
+        def funder = new RegTestOmniFundingSource(client, new RegTestFundingSource(client))
         return [client, env, funder]
     }
 }

--- a/omnij-rpc/src/main/groovy/foundation/omni/test/RegTestOmniFundingSource.groovy
+++ b/omnij-rpc/src/main/groovy/foundation/omni/test/RegTestOmniFundingSource.groovy
@@ -1,6 +1,8 @@
 package foundation.omni.test
 
 import foundation.omni.rpc.test.OmniTestClient;
+import foundation.omni.rpc.test.OmniTestClientAccessor
+import org.consensusj.bitcoin.jsonrpc.test.FundingSource;
 import org.consensusj.bitcoin.jsonrpc.test.RegTestFundingSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,11 +11,21 @@ import org.slf4j.LoggerFactory;
  * This should be converted to Java.
  * So let's keep it in Java-like Groovy until then
  */
-public class RegTestOmniFundingSource extends RegTestFundingSource implements OmniTestSupport, OmniFundingSource  {
+public class RegTestOmniFundingSource extends RegTestFundingSource implements OmniTestClientAccessor, OmniTestSupport, OmniFundingSource  {
     private static final Logger log = LoggerFactory.getLogger(RegTestFundingSource.class);
+    RegTestFundingSource fundingSource;
 
-    public RegTestOmniFundingSource(OmniTestClient client) {
+    public RegTestOmniFundingSource(OmniTestClient client, RegTestFundingSource fundingSource) {
         super(client);          // Set BitcoinExtendedClient in superclass
-        foundation_omni_test_OmniTestClientDelegate__client = client;   // Set Omni client here
+        this.fundingSource = fundingSource;
+    }
+
+    OmniTestClient client() {
+        return client;
+    }
+
+    @Override
+    FundingSource fundingSource() {
+        return fundingSource
     }
 }


### PR DESCRIPTION
* Update for significant changes in test class inheritance in CJ 0.6.4
* OmniTestSupport becomes an interface with default methods (was a trait)
* OmniTestClientAccessor interface is replacement for deprecated OmniTestClientDelegate
* @Ignore OmniCreateTokenScriptSpec (for now, at least)