### PR TITLE
OmniTransactionInfo: add totalAmount property for SendToMany

### DIFF
--- a/omnij-jsonrpc/src/main/java/foundation/omni/json/pojo/OmniTransactionInfo.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/json/pojo/OmniTransactionInfo.java
@@ -40,6 +40,7 @@ public class OmniTransactionInfo {
     private final int typeInt;
     private final String type;
     private final OmniValue amount;
+    private final OmniValue totalAmount;
     private final boolean divisible;
     private final CurrencyID propertyId;
     private final Sha256Hash blockHash;
@@ -63,6 +64,7 @@ public class OmniTransactionInfo {
                                @JsonProperty("type_int")            int         typeInt,
                                @JsonProperty("type")                String      type,
                                @JsonProperty("amount")              OmniValue   amount,
+                               @JsonProperty("totalamount")         OmniValue   totalAmount,
                                @JsonProperty("divisible")           boolean     divisible,
                                @JsonProperty("propertyid")          CurrencyID  propertyId,
                                @JsonProperty("blockhash")           Sha256Hash  blockHash,
@@ -83,6 +85,7 @@ public class OmniTransactionInfo {
         this.typeInt = typeInt;
         this.type = type;
         this.amount = amount;
+        this.totalAmount = totalAmount;
         this.divisible = divisible;
         this.propertyId = propertyId;
         this.blockHash = blockHash;
@@ -164,6 +167,10 @@ public class OmniTransactionInfo {
 
     public OmniValue getAmount() {
         return amount;
+    }
+
+    public OmniValue getTotalAmount() {
+        return totalAmount;
     }
 
     public boolean isDivisible() {

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendtomany/SendToManySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sendtomany/SendToManySpec.groovy
@@ -3,7 +3,6 @@ package foundation.omni.test.rpc.sendtomany
 import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
 import foundation.omni.OmniOutput
-import foundation.omni.OmniValue
 import org.junit.jupiter.api.Assumptions
 
 class SendToManySpec extends BaseRegTestSpec {
@@ -42,7 +41,7 @@ class SendToManySpec extends BaseRegTestSpec {
 
         then: "the transaction is valid and all destinations receivers the correct balance"
         sendTx.valid
-        OmniValue.of(sendTx.totalamount) == 0.00000028.divisible
+        sendTx.totalAmount == 0.00000028.divisible
         omniGetBalance(otherAddress1, CurrencyID.OMNI).balance == 0.00000001.divisible
         omniGetBalance(otherAddress2, CurrencyID.OMNI).balance == 0.00000002.divisible
         omniGetBalance(otherAddress3, CurrencyID.OMNI).balance == 0.00000003.divisible
@@ -85,7 +84,7 @@ class SendToManySpec extends BaseRegTestSpec {
 
         then: "the transaction is valid and all destinations receivers the correct balance"
         sendTx.valid
-        OmniValue.of(sendTx.totalamount) == 0.00000036.divisible
+        sendTx.totalAmount == 0.00000036.divisible
         omniGetBalance(otherAddress1, CurrencyID.OMNI).balance == 0.00000001.divisible
         omniGetBalance(otherAddress2, CurrencyID.OMNI).balance == 0.00000002.divisible
         omniGetBalance(otherAddress3, CurrencyID.OMNI).balance == 0.00000003.divisible
@@ -118,7 +117,7 @@ class SendToManySpec extends BaseRegTestSpec {
 
         then: "the transaction is valid and the receiver received the correct number of tokens"
         sendTx.valid
-        OmniValue.of(sendTx.totalamount) == 0.00000227.divisible
+        sendTx.totalAmount == 0.00000227.divisible
         omniGetBalance(otherAddressA, CurrencyID.TOMNI).balance == 0.00000220.divisible
         omniGetBalance(otherAddressB, CurrencyID.TOMNI).balance == 0.00000007.divisible
     }


### PR DESCRIPTION
* OmniTransactionInfo: add totalAmount property
* SendToManySpec.groovy: use camel-case totalAmount

(This fixes failures that I found testing against the current develop branch where the test for the `omni_sendtomany` method succeeds and the SendToManySpec is run)

Depends on PR #215 (to avoid a merge)
