### PR TITLE
SendToOwnersTestPlanSpec.executeSendToOwners(): log exceptions

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToOwnersTestPlanSpec.groovy
@@ -407,7 +407,12 @@ class SendToOwnersTestPlanSpec extends BaseRegTestSpec {
 
         try {
             txid = omniSendSTO(address, currency, amount)
-        } catch(Exception) {
+        } catch(Exception e) {
+            if (exceptional) {
+                log.debug("Expected exception: ", e)
+            } else {
+                log.error("Unexpected exception: ", e)
+            }
             thrown = true
         }
 


### PR DESCRIPTION
I saw an intermittent and unexplained assertion failure (line 419, `assert thrown == exceptional`) in this method in a Github Actions run, so am adding this logging to (hopefully) catch it next time.