### PR TITLE
ManagedPropertySpec - re-enable sending-of-granted test

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/smartproperty/ManagedPropertySpec.groovy
@@ -221,7 +221,6 @@ class ManagedPropertySpec extends BaseRegTestSpec {
         omniGetBalance(otherAddress, currencyID).balance == 1
     }
 
-    @Ignore
     def "Sending of granted tokens does not remove the limit of total tokens"() {
         when:
         def txid = grantTokens(actorAddress, currencyID, 1.indivisible) // MAX < total + 1 (!)


### PR DESCRIPTION
Re-enable "Sending of granted tokens does not remove the limit of total tokens" test.