### PR TITLE
GitHub graalvm workflow: Use latest GraalVM 17 (community)

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -8,18 +8,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        graalvm: [ '22.3.1' ]
-        java: [ '17' ]
+        java-version: [ '17' ]
+        distribution: [ 'graalvm-community' ]
       fail-fast: false
-    name: ${{ matrix.os }} JDK ${{ matrix.graalvm }}
+    name: ${{ matrix.os }} JDK ${{ matrix.java-version }}.${{ matrix.distribution }}
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
     - name: Set up GraalVM
       uses: graalvm/setup-graalvm@v1
       with:
-        version: ${{ matrix.graalvm }}
-        java-version: ${{ matrix.java }}
+        java-version: ${{ matrix.java-version }}
+        distribution: ${{ matrix.distribution }}
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Verify Gradle Wrapper

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ The 0.7.0 release of **OmniJ** will require the forthcoming **ConsensusJ** 0.7.0
 === Build/Test Updates
 
 * JUnit Jupiter 5.9.3
+* Use latest GraalVM 17 (new version numbering mechanism) on GitHub Actions
 
 == v0.6.3
 


### PR DESCRIPTION
Use the latest release and the new version numbering system.