### PR TITLE
Omni Retrofit REST client: OkHttp 3.14.9, Retrofit 2.9.0

### DIFF
--- a/omnij-rest-client-retrofit/build.gradle
+++ b/omnij-rest-client-retrofit/build.gradle
@@ -9,11 +9,11 @@ dependencies {
     api project(':omnij-jsonrpc')
     api project(':omnij-net-api')
 
-    api 'com.squareup.okhttp3:okhttp:3.12.8'   // OmniwalletClient constructor with OkHttp parameter
-    api 'com.squareup.retrofit2:retrofit:2.6.4'
+    api 'com.squareup.okhttp3:okhttp:3.14.9'   // OmniwalletClient constructor with OkHttp parameter
+    api 'com.squareup.retrofit2:retrofit:2.9.0'
 
-    implementation 'com.squareup.retrofit2:converter-jackson:2.6.4'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.8'
+    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
 
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 


### PR DESCRIPTION
Upgrade to the latest versions before OkHttp 4.x and Retrofit 3.x, respectively. (This is where the Kotlin dependency was introduced.)