### PR TITLE
SendToOwnersReorgSpec: Use convenient function to check transaction validity

### DIFF
--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/reorgs/SendToOwnersReorgSpec.groovy
@@ -162,11 +162,9 @@ class SendToOwnersReorgSpec extends BaseReorgSpec {
         clearMemPool()
         delayAfterInvalidate()  // Sleep for a little while to avoid `ProcessNewBlock, block not accepted` (duplicate block)
         generateBlocks(1)
-        def secondOrphanedTx = omniGetTransaction(secondTxid)
 
         then: "the transaction is not valid"
-        !secondOrphanedTx.valid
-        // secondOrphanedTx.confirmations == -1 TODO: activate after Omni Core adjustment
+        !checkTransactionValidity(secondTxid)
 
         when: "creating a third STO transaction"
         requestBitcoin(actorAddress, Coin.CENT)  // maybe use startBTC instead


### PR DESCRIPTION
Transaction is not part of blockchain anymore so it could not be part of omni database as well.