### PR TITLE
Update to newer bitcoinj, ConsensusJ

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ There are currently ten active subprojects of OmniJ. Each of which builds a JAR 
 
 | omnij-cli
 | Omni consensus-checking command-line tool.
-| 17
+| 21
 | Can be natively compiled with *GraalVM* `native-image`.
 
 | omnij-core
@@ -157,7 +157,7 @@ If you are using the `omnij-jsonrpc` JAR, add the following:
 
 === Building OmniJ
 
-The only prerequisite for building OmniJ is having Java JDK 11 or later installed (JDK 17 is recommended.) All other prerequisites are downloaded automatically by the http://gradle.org/docs/current/userguide/gradle_wrapper.html[Gradle Wrapper] script.
+The only prerequisite for building OmniJ is having Java JDK 17 or later installed (JDK 21 is recommended.) All other prerequisites are downloaded automatically by the http://gradle.org/docs/current/userguide/gradle_wrapper.html[Gradle Wrapper] script.
 
 . Check out this project using Git
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ omnijVersion = 0.7.0-SNAPSHOT
 
 useMavenLocal = false
 
-bitcoinjVersion = 0.17-alpha2
+bitcoinjVersion = 0.17-rc2
 consensusjVersion = 0.7.0-alpha3
 slf4jVersion = 2.0.9
 groovyVersion = 4.0.15

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@ omnijVersion = 0.7.0-SNAPSHOT
 
 useMavenLocal = false
 
-bitcoinjVersion = 0.17-rc2
-consensusjVersion = 0.7.0-alpha3
-slf4jVersion = 2.0.9
-groovyVersion = 4.0.15
+bitcoinjVersion = 0.17.1
+consensusjVersion = 0.7.0-beta2
+slf4jVersion = 2.0.17
+groovyVersion = 4.0.30
 spockVersion = 2.3-groovy-4.0
 junitJupiterVersion = 5.10.0
 

--- a/gradle/groovydoc.gradle
+++ b/gradle/groovydoc.gradle
@@ -23,7 +23,7 @@ allprojects {
     }
 
     dependencies {
-        documentation 'com.github.javaparser:javaparser-core:3.15.14'
+        documentation 'com.github.javaparser:javaparser-core:3.28.0'
         documentation "org.apache.groovy:groovy-ant:${groovyVersion}"
         documentation "org.apache.groovy:groovy-templates:${groovyVersion}"
     }

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -2,14 +2,15 @@ ext.javadocSpec = {
     def javaDocLinks = [
             'https://docs.oracle.com/en/java/javase/11/docs/api/',
             "https://www.consensusj.org/consensusj/apidoc/",
-            // javadoc.io is down on 10/4/2023 and beaking the build, try renabling later?
+            // javadoc.io is down on 10/4/2023 and breaking the build, try re-enabling later?
             // Or maybe use the -linkoffline option?
             // "https://javadoc.io/doc/javax.money/money-api/1.1/",
             "https://fasterxml.github.io/jackson-core/javadoc/2.13/",
             "https://fasterxml.github.io/jackson-databind/javadoc/2.13/"
     ]
 
-    if (!bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("rc")) {
+    if (!bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("beta")
+            && !bitcoinjVersion.contains("rc") && !bitcoinjVersion.contains("0.17.1")) {
         javaDocLinks.add("https://bitcoinj.org/javadoc/${bitcoinjVersion}/".toString())
     }
 

--- a/omnij-cli/src/integ/groovy/foundation/omni/cli/ConsensusCLISpec.groovy
+++ b/omnij-cli/src/integ/groovy/foundation/omni/cli/ConsensusCLISpec.groovy
@@ -7,7 +7,6 @@ import foundation.omni.rpc.test.TestServers
 import spock.lang.Ignore
 import spock.lang.Specification
 
-
 /**
  * Integration test of ConsensusCLI in RegTest mode
  * Assumes bitcoind running on localhost in RegTest mode.
@@ -23,9 +22,9 @@ class ConsensusCLISpec extends Specification implements CLITestSupport {
         def result = command '-?'
 
         then:
-        result.status == 0
-        result.output.length() == 0
-        result.error.length() >= 0
+        result.status() == 0
+        result.output().length() == 0
+        result.error().length() >= 0
     }
 
     def "fetch Omni consensus to stdout"() {
@@ -33,9 +32,9 @@ class ConsensusCLISpec extends Specification implements CLITestSupport {
         def result = command "-regtest -rpcconnect=${rpcHost} -rpcuser=${rpcUser} -rpcpassword=${rpcPassword} -rpcwait -property 1"
 
         then:
-        result.status == 0
-        result.output.length() >= 0
-        result.error.length() == 0
+        result.status() == 0
+        result.output().length() >= 0
+        result.error().length() == 0
     }
 
     def "no currency specified, should output help"() {
@@ -43,9 +42,9 @@ class ConsensusCLISpec extends Specification implements CLITestSupport {
         def result = command '-regtest -rpcwait'
 
         then:
-        result.status == 1
-        result.output.length() == 0
-        result.error.length() >= 0
+        result.status() == 1
+        result.output().length() == 0
+        result.error().length() >= 0
     }
 
     def "fetch Omni consensus to stdout with rpcconnect option"() {
@@ -53,9 +52,9 @@ class ConsensusCLISpec extends Specification implements CLITestSupport {
         def result = command "-regtest -rpcconnect=${rpcHost} -rpcuser=${rpcUser} -rpcpassword=${rpcPassword} -rpcwait -property=1 -rpcconnect=127.0.0.1"
 
         then:
-        result.status == 0
-        result.output.length() >= 0
-        result.error.length() == 0
+        result.status() == 0
+        result.output().length() >= 0
+        result.error().length() == 0
     }
 
     def "Compare Omni consensus of all properties (using localhost as a dummy for remote-core)"() {
@@ -64,9 +63,9 @@ class ConsensusCLISpec extends Specification implements CLITestSupport {
                 "--omnicore-url=http://${rpcUser}:${rpcPassword}@${rpcHost}:18443/"
 
         then:
-        result.status == 0
-        result.output.length() >= 0
-        result.error.length() == 0
+        result.status() == 0
+        result.output().length() >= 0
+        result.error().length() == 0
     }
 
     @Ignore("This is no longer throwing an exception, need to review whether it should be throwing one")
@@ -94,10 +93,10 @@ class ConsensusCLISpec extends Specification implements CLITestSupport {
      * @return  status and output streams in Strings
      */
     protected CLICommandResult command(String line) {
-        String[] args = parseCommandLine(line)     // Parse line into separate args
+        String[] args = line.split(' ')
 
         // Run the command
         ConsensusCLI cli = new ConsensusCLI()
-        return runTool(cli, args)
+        return CLITestSupport.runTool(cli, args)
     }
 }

--- a/omnij-cli/src/main/java/foundation/omni/cli/ConsensusCLI.java
+++ b/omnij-cli/src/main/java/foundation/omni/cli/ConsensusCLI.java
@@ -58,17 +58,9 @@ public class ConsensusCLI extends BitcoinCLITool {
     }
 
     public static void main(String[] args) {
-        try {
-            ConsensusCLI command = new ConsensusCLI();
-            OmniCoreCLICall call = new OmniCoreCLICall(command, System.out, System.err, args);
-            command.run(call);
-        } catch (ToolException te) {
-            System.exit(te.resultCode);
-        } catch (Throwable e) {
-            e.printStackTrace();
-            System.exit(1);
-        }
-        System.exit(0);
+        ConsensusCLI command = new ConsensusCLI();
+        int resultCode = command.run( System.out, System.err, args);
+        System.exit(resultCode);
     }
 
     @Override
@@ -77,12 +69,16 @@ public class ConsensusCLI extends BitcoinCLITool {
     }
 
     @Override
-    public void run(Call call) {
+    public int run(PrintWriter out, PrintWriter err, String... args) {
         try {
-            run((OmniCoreCLICall) call);
-        } catch (IOException | InterruptedException | ExecutionException e) {
-            throw new RuntimeException(e);
+            OmniCoreCLICall call = new OmniCoreCLICall(this, System.out, System.err, args);
+            run(call);
+        } catch (ToolException e) {
+            return e.resultCode;
+        } catch (Exception e) {
+            throw new RuntimeException((e));
         }
+        return 0;
     }
 
     public void run(OmniCoreCLICall call) throws IOException, InterruptedException, ExecutionException {
@@ -91,7 +87,7 @@ public class ConsensusCLI extends BitcoinCLITool {
         // Must have -p (property id) or -x (compare)
         if (!(line.hasOption("p") || line.hasOption("x"))) {
             printError(call, "Must either specify a property id with -p and/or the -x/-compare option");
-            printHelp(call, commandUsage);
+            printHelp(call.out, commandUsage);
             throw new ToolException(1, "usage error");
         }
 
@@ -117,7 +113,7 @@ public class ConsensusCLI extends BitcoinCLITool {
 
         if (line.hasOption("compare") && (tool2 == null) ) {
             printError(call, "-omnicore-url or -omniwallet-url must be specified for -x/-compare option");
-            printHelp(call, commandUsage);
+            printHelp(call.out, commandUsage);
             throw new ToolException(1, "usage error");
         } else if (line.hasOption("compare")) {
             MultiPropertyComparison multiComparison = new MultiPropertyComparison(tool1, tool2);

--- a/omnij-core/src/main/java/foundation/omni/address/OmniSegwitAddressConverter.java
+++ b/omnij-core/src/main/java/foundation/omni/address/OmniSegwitAddressConverter.java
@@ -15,7 +15,7 @@ public class OmniSegwitAddressConverter {
     public static SegwitAddress btcToOmni(SegwitAddress btcAddress) {
         OmniNetwork omniNet = btcNetworkToOmniNetwork((BitcoinNetwork) btcAddress.network());
         Bech32.Bech32Data btcBech32Data = Bech32.decode(btcAddress.toBech32());
-        String omniAddressString = Bech32.encode(Bech32.Encoding.BECH32, omniNet.segwitAddressHrp(), btcBech32Data.data);
+        String omniAddressString = Bech32.encode(Bech32.Encoding.BECH32, omniNet.segwitAddressHrp(), btcBech32Data);
         return (SegwitAddress) OmniNetwork.addressParser.forNetwork(omniNet).parseAddress(omniAddressString);
     }
 
@@ -27,7 +27,7 @@ public class OmniSegwitAddressConverter {
     public static SegwitAddress omniToBtc(SegwitAddress omniAddress) {
         BitcoinNetwork btcNet = omniNetworkToBtcNetwork((OmniNetwork) omniAddress.network());
         Bech32.Bech32Data btcBech32Data = Bech32.decode(omniAddress.toBech32());
-        String btcAddressString = Bech32.encode(Bech32.Encoding.BECH32, btcNet.segwitAddressHrp(), btcBech32Data.data);
+        String btcAddressString = Bech32.encode(Bech32.Encoding.BECH32, btcNet.segwitAddressHrp(), btcBech32Data);
         return (SegwitAddress) OmniNetwork.addressParser.forNetwork(btcNet).parseAddress(btcAddressString);
     }
 

--- a/omnij-core/src/main/java/foundation/omni/tx/ClassCEncoder.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/ClassCEncoder.java
@@ -63,7 +63,7 @@ public class ClassCEncoder {
     public TransactionOutput encodeOpReturnOutput(byte[] payload) {
         Script script = createOmniTxOpReturnScript(payload);
 
-        return new TransactionOutput(null, Coin.ZERO, script.getProgram());
+        return new TransactionOutput(null, Coin.ZERO, script.program());
     }
 
     /**

--- a/omnij-core/src/main/java/foundation/omni/tx/EncodeMultisig.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/EncodeMultisig.java
@@ -61,26 +61,12 @@ public class EncodeMultisig {
             redeemableGroup.add(redeemingKey);
             redeemableGroup.addAll(group);
             Script script = ScriptBuilder.createMultiSigOutputScript(1, redeemableGroup); // 1 of redeemableGroup.size() multisig
-            TransactionOutput output = new TransactionOutput(null, Coin.ZERO, script.getProgram());
-            output.setValue(calcNonDustValue(output));
+            TransactionOutput output = new TransactionOutput(null, Coin.ZERO, script.program());
+            output.setValue(output.getMinNonDustValue());
             txClassB.addOutput(output);
         }
 
         return txClassB;
-    }
-
-    // Calculate the non-dust output value for a Class B multi-sig output
-    private Coin calcNonDustValue(TransactionOutput output) {
-        boolean useWorkaround = true;
-        if (useWorkaround) {
-            // This is a workaround until https://github.com/bitcoinj/bitcoinj/pull/3120 is merged and
-            // a new bitcoinj 0.17-xxx is released.
-            Coin feePerKb = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.multiply(3);
-            long size = output.bitcoinSerialize().length + 32 + 4 + 1 + 107 + 4; // 148
-            return feePerKb.multiply(size).divide(1000);
-        } else {
-            return output.getMinNonDustValue();
-        }
     }
 
     /**

--- a/omnij-core/src/main/java/foundation/omni/tx/EncodeMultisig.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/EncodeMultisig.java
@@ -61,8 +61,8 @@ public class EncodeMultisig {
             redeemableGroup.add(redeemingKey);
             redeemableGroup.addAll(group);
             Script script = ScriptBuilder.createMultiSigOutputScript(1, redeemableGroup); // 1 of redeemableGroup.size() multisig
-            TransactionOutput output = new TransactionOutput(null, Coin.ZERO, script.program());
-            output.setValue(output.getMinNonDustValue());
+            TransactionOutput tmpOutput = new TransactionOutput(null, Coin.ZERO, script.program());
+            TransactionOutput output = new TransactionOutput(null, tmpOutput.getMinNonDustValue(), script.program());
             txClassB.addOutput(output);
         }
 

--- a/omnij-core/src/main/java/foundation/omni/tx/OmniTxBuilder.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/OmniTxBuilder.java
@@ -123,7 +123,9 @@ public class OmniTxBuilder {
      */
     static void addDustOutput(Transaction tx, Address address) {
         TransactionOutput output = tx.addOutput(Coin.ZERO, address);    // Add Output with zero amount
-        output.setValue(output.getMinNonDustValue());                   // Adjust to minimum non-dust value
+        int index = output.getIndex();
+        // Adjust to minimum non-dust value
+        tx.replaceOutput(index, output.withValue(output.getMinNonDustValue()));
     }
 
     /**
@@ -173,9 +175,9 @@ public class OmniTxBuilder {
             TransactionSignature signature = tx.calculateSignature(i, fromKey, scriptPubKey, Transaction.SigHash.ALL, false);
             // ScriptPattern should match scriptType or error
             if (ScriptPattern.isP2PK(scriptPubKey))
-                input.setScriptSig(ScriptBuilder.createInputScript(signature));
+                tx.replaceInput(i, input.withScriptSig(ScriptBuilder.createInputScript(signature)));
             else if (ScriptPattern.isP2PKH(scriptPubKey))
-                input.setScriptSig(ScriptBuilder.createInputScript(signature, fromKey));
+                tx.replaceInput(i, input.withScriptSig(ScriptBuilder.createInputScript(signature, fromKey)));
             else if (ScriptPattern.isP2SH(scriptPubKey))
                 // TODO: Support signing P2SH(P2WPKH) here
                 // (since this method takes a single ECKey we don't need multisig support in this method)

--- a/omnij-core/src/main/java/foundation/omni/tx/PubKeyConversion.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/PubKeyConversion.java
@@ -69,7 +69,7 @@ public class PubKeyConversion {
             try {
                 // Create a Bouncy Castle ECPoint to make sure this pubkey is valid. As of bitcoinj 0.15.10,
                 // ECKey itself is lazy and won't validate at construction, so we create the point first.
-                key = ECKey.fromPublicOnly(ECKey.CURVE.getCurve().decodePoint(pub), true);
+                key = ECKey.fromPublicOnly(ECKey.ecDomainParameters().getCurve().decodePoint(pub), true);
             } catch (IllegalArgumentException e) {
                 valid = false;
                 key = null;

--- a/omnij-core/src/main/java/foundation/omni/tx/SimpleVariableFeeCalculator.java
+++ b/omnij-core/src/main/java/foundation/omni/tx/SimpleVariableFeeCalculator.java
@@ -9,7 +9,7 @@ import org.bitcoinj.core.Transaction;
 public class SimpleVariableFeeCalculator implements FeeCalculator {
     @Override
     public Coin calculateFee(Transaction tx) {
-        long fee = (tx.getMessageSize() * Transaction.DEFAULT_TX_FEE.getValue()) / 1024;
+        long fee = (tx.messageSize() * Transaction.DEFAULT_TX_FEE.getValue()) / 1024;
         return Coin.valueOf(fee);
     }
 }

--- a/omnij-core/src/test/groovy/foundation/omni/tx/BitcoinJTransactionBuilderSpec.groovy
+++ b/omnij-core/src/test/groovy/foundation/omni/tx/BitcoinJTransactionBuilderSpec.groovy
@@ -37,7 +37,7 @@ class BitcoinJTransactionBuilderSpec extends BaseTxSpec {
         Script script = ScriptBuilder.createInputScript(null)
         def outPoint = new TransactionOutPoint(1, Sha256Hash.of("boppitybop".getBytes()))
 
-        TransactionInput input = new TransactionInput(null, script.program, outPoint, null)
+        TransactionInput input = new TransactionInput(null, script.program(), outPoint, null)
         tx.addInput(input)
         byte[] rawTx = tx.bitcoinSerialize()
 

--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniClient.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniClient.java
@@ -110,8 +110,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @throws IOException network error
      */
     public Map<String, Object> omniGetInfo() throws JsonRpcException, IOException {
-        Map<String, Object> result = send("omni_getinfo");
-        return result;
+        return (Map<String, Object>) send("omni_getinfo");
     }
 
     /**
@@ -123,7 +122,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<SmartPropertyListInfo> omniListProperties() throws JsonRpcException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, SmartPropertyListInfo.class);
-        return send("omni_listproperties", resultType);
+        return (List<SmartPropertyListInfo> ) send("omni_listproperties", resultType);
     }
 
     /**
@@ -135,8 +134,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @throws IOException network error
      */
     public OmniPropertyInfo omniGetProperty(CurrencyID currency) throws JsonRpcException, IOException {
-        OmniPropertyInfo result = send("omni_getproperty", OmniPropertyInfo.class, currency);
-        return result;
+        return send("omni_getproperty", OmniPropertyInfo.class, currency);
     }
 
     /**
@@ -148,8 +146,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @throws IOException network error
      */
     public Map<String, Object> omniGetCrowdsale(CurrencyID currency) throws JsonRpcException, IOException {
-        Map<String, Object> result = send("omni_getcrowdsale", currency);
-        return result;
+        return (Map<String, Object>) send("omni_getcrowdsale", currency);
     }
 
     /**
@@ -160,8 +157,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @throws IOException network error
      */
     public List<Map<String, Object>> omniGetActiveCrowdsales() throws JsonRpcException, IOException {
-        List<Map<String, Object>> result = send("omni_getactivecrowdsales");
-        return result;
+        return (List<Map<String, Object>>) send("omni_getactivecrowdsales");
     }
 
     /**
@@ -172,8 +168,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @throws IOException network error
      */
     public List<Map<String, Object>> omniGetActiveDExSells() throws JsonRpcException, IOException {
-        List<Map<String, Object>> result = send("omni_getactivedexsells");
-        return result;
+        return (List<Map<String, Object>>) send("omni_getactivedexsells");
     }
 
     /**
@@ -214,7 +209,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
     public List<AddressBalanceEntry> omniGetAllBalancesForIdAsList(CurrencyID currency)
             throws JsonRpcException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, AddressBalanceEntry.class);
-        return send("omni_getallbalancesforid", resultType, currency);
+        return (List<AddressBalanceEntry>) send("omni_getallbalancesforid", resultType, currency);
     }
 
     /**
@@ -241,7 +236,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
     public List<PropertyBalanceEntry> omniGetAllBalancesForAddressAsList(Address address)
             throws JsonRpcException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, PropertyBalanceEntry.class);
-        return send("omni_getallbalancesforaddress", resultType, address);
+        return (List<PropertyBalanceEntry>) send("omni_getallbalancesforaddress", resultType, address);
     }
 
     /**
@@ -278,7 +273,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<OmniTransactionInfo> omniListTransactions(String addressFilter, Integer count, Integer skip, Integer startBlock, Integer endBlock) throws JsonRpcException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, OmniTransactionInfo.class);
-        return send("omni_listtransactions", resultType, addressFilter, count, skip, startBlock, endBlock);
+        return (List<OmniTransactionInfo>) send("omni_listtransactions", resultType, addressFilter, count, skip, startBlock, endBlock);
     }
 
     /**
@@ -291,7 +286,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<Sha256Hash> omniListBlockTransactions(Integer blockIndex) throws JsonRpcException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, Sha256Hash.class);
-        return send("omni_listblocktransactions", resultType, blockIndex);
+        return (List<Sha256Hash> ) send("omni_listblocktransactions", resultType, blockIndex);
     }
 
     /**
@@ -682,7 +677,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public Map<String, Object> omniGetSTO(Sha256Hash txid) throws JsonRpcException, IOException {
         String filter = "*"; // no filter at all
-        return send("omni_getsto", txid, filter);
+        return (Map<String, Object>) send("omni_getsto", txid, filter);
     }
 
     /**
@@ -700,7 +695,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
 
     public List<OmniTradeInfo> omniGetTradeHistoryForAddress(Address address, Integer count, CurrencyID propertyId) throws JsonRpcException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, OmniTradeInfo.class);
-        return send("omni_gettradehistoryforaddress", resultType, address, count, propertyId);
+        return (List<OmniTradeInfo>) send("omni_gettradehistoryforaddress", resultType, address, count, propertyId);
     }
 
     /**
@@ -713,7 +708,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @since Omni Core 0.0.10
      */
     public List<Map<String, Object>> omniGetOrderbook(CurrencyID propertyForSale) throws JsonRpcException, IOException {
-        return send("omni_getorderbook", propertyForSale);
+        return (List<Map<String, Object>>) send("omni_getorderbook", propertyForSale);
     }
 
     /**
@@ -728,7 +723,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<Map<String, Object>> omniGetOrderbook(CurrencyID propertyForSale, CurrencyID propertyDesired)
             throws JsonRpcException, IOException {
-        return send("omni_getorderbook", propertyForSale, propertyDesired);
+        return (List<Map<String, Object>>) send("omni_getorderbook", propertyForSale, propertyDesired);
     }
 
     /**
@@ -740,7 +735,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @throws IOException network error
      */
     public List<Map<String, Object>> omniGetGrants(CurrencyID propertyid) throws JsonRpcException, IOException {
-        return send("omni_getgrants", propertyid);
+        return (List<Map<String, Object>>) send("omni_getgrants", propertyid);
     }
 
     /**
@@ -752,7 +747,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      * @since Omni Core 0.0.10
      */
     public Map<String, List<Map<String, Object>>> omniGetActivations() throws JsonRpcException, IOException {
-        return send("omni_getactivations");
+        return (Map<String, List<Map<String, Object>>>) send("omni_getactivations");
     }
 
     /**
@@ -769,7 +764,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<Map<String, Object>> omniGetFeeCache(CurrencyID propertyid)
             throws JsonRpcException, IOException {
-        return send("omni_getfeecache", propertyid);
+        return (List<Map<String, Object>>) send("omni_getfeecache", propertyid);
     }
 
     /**
@@ -786,7 +781,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<Map<String, Object>> omniGetFeeTrigger(CurrencyID propertyId)
             throws JsonRpcException, IOException {
-        return send("omni_getfeetrigger", propertyId);
+        return (List<Map<String, Object>>) send("omni_getfeetrigger", propertyId);
     }
 
     /**
@@ -807,7 +802,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<Map<String, Object>> omniGetFeeShare(Address address, Ecosystem ecosystem)
             throws JsonRpcException, IOException {
-        return send("omni_getfeeshare", Objects.requireNonNullElse(address, ""), ecosystem);
+        return (List<Map<String, Object>>) send("omni_getfeeshare", Objects.requireNonNullElse(address, ""), ecosystem);
     }
 
     /**
@@ -823,7 +818,7 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public Map<String, Object> omniGetFeeDistribution(Integer distributionId)
             throws JsonRpcException, IOException {
-        return send("omni_getfeedistribution", distributionId);
+        return (Map<String, Object>) send("omni_getfeedistribution", distributionId);
     }
 
     /**
@@ -839,6 +834,6 @@ public class OmniClient extends RxBitcoinClient implements OmniClientRawTxSuppor
      */
     public List<Map<String, Object>> omniGetFeeDistributions(CurrencyID propertyId)
             throws JsonRpcException, IOException {
-        return send("omni_getfeedistributions", propertyId);
+        return (List<Map<String, Object>>) send("omni_getfeedistributions", propertyId);
     }
 }

--- a/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniProxyMethods.java
+++ b/omnij-jsonrpc/src/main/java/foundation/omni/rpc/OmniProxyMethods.java
@@ -38,7 +38,7 @@ public interface OmniProxyMethods extends JsonRpcClient<JavaType> {
 
     private List<OmniPropertyInfo> omniProxyListPropertiesSync() throws IOException {
         JavaType javaType = collectionTypeForClasses(List.class, OmniPropertyInfo.class);
-        return send("omniproxy.listproperties", javaType);
+        return (List<OmniPropertyInfo>) send("omniproxy.listproperties", javaType);
     }
 
     default CompletableFuture<List<OmniPropertyInfo>> omniProxyListProperties()  {


### PR DESCRIPTION
This is passing all tests _except_ regTests. ConsensusJ 0.7.0-beta1 was updated to support Bitcoin Core v30+ and in the process lost support for Bitcoin Core v20.1 / Omni Core v0.12.0.

I will release ConsensusJ 0.7.0-beta2 which will enable that support and then update this PR.